### PR TITLE
chore: Add dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - chore
+      - dependencies


### PR DESCRIPTION
This pull request introduces a `dependabot` configuration file to automate dependency updates for the project. The configuration specifies weekly updates for Go modules with appropriate labels for tracking.

Dependency automation:

* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR1-R9): Added a `dependabot` configuration file to enable weekly dependency updates for the `gomod` package ecosystem in the root directory, with labels `chore` and `dependencies`.