### PR TITLE
docs: Highlight required flag note in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ mongo2dynamo apply \
 
 ### Command-line Flags
 
+> [!NOTE]
+> \* Required for `apply` command, optional for `plan` command.
+
 | Flag | Description | Required | Default |
 |------|-------------|----------|---------|
 | `--mongo-host` | MongoDB host | No | localhost |
@@ -55,8 +58,6 @@ mongo2dynamo apply \
 | `--aws-region` | AWS region | No | us-east-1 |
 | `--auto-approve` | Skip confirmation prompt | No | false |
 | `--dry-run` | Show what would be migrated without actually migrating | No | false |
-
-\* Required for `apply` command, optional for `plan` command
 
 ## Environment Variables
 


### PR DESCRIPTION
This pull request updates the `README.md` file to improve the documentation for the `mongo2dynamo` tool by clarifying the requirements for the `apply` and `plan` commands.

Documentation improvements:

* Added a note indicating that certain flags are required for the `apply` command but optional for the `plan` command. (`README.md`, [README.mdR45-R47](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R47))
* Removed redundant text about flag requirements for the `apply` and `plan` commands, as it is now included in the note. (`README.md`, [README.mdL59-L60](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-L60))