### PR TITLE
feat: Disable completion command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().Bool("auto-approve", false, "Skip confirmation prompt")
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	bindPersistentFlags()
 }
 


### PR DESCRIPTION
This pull request introduces a minor change to the `cmd/root.go` file. The change disables the default completion command for the `rootCmd` by setting `DisableDefaultCmd` to `true`.