### PR TITLE
chore: Add goreleaser configurations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,10 @@ jobs:
           
           # Fetch checksums.txt from the release
           CHECKSUMS=$(curl -sL https://github.com/dutymate/mongo2dynamo/releases/download/v${VERSION}/checksums.txt)
+          if [ $? -ne 0 ] || [ -z "$CHECKSUMS" ]; then
+            echo "Error: Failed to fetch checksums.txt from the release. Please check the URL or network connection."
+            exit 1
+          fi
           
           # Extract SHA256 for each platform
           DARWIN_AMD64_SHA=$(echo "$CHECKSUMS" | grep darwin_amd64.tar.gz | awk '{print $1}')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,71 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  homebrew:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: dutymate/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew formula
+        run: |
+          cd homebrew-tap
+          VERSION=$(echo $GITHUB_REF | sed 's/refs\/tags\/v//')
+          
+          # Fetch checksums.txt from the release
+          CHECKSUMS=$(curl -sL https://github.com/dutymate/mongo2dynamo/releases/download/v${VERSION}/checksums.txt)
+          
+          # Extract SHA256 for each platform
+          DARWIN_AMD64_SHA=$(echo "$CHECKSUMS" | grep darwin_amd64.tar.gz | awk '{print $1}')
+          DARWIN_ARM64_SHA=$(echo "$CHECKSUMS" | grep darwin_arm64.tar.gz | awk '{print $1}')
+          LINUX_AMD64_SHA=$(echo "$CHECKSUMS" | grep linux_amd64.tar.gz | awk '{print $1}')
+          LINUX_ARM64_SHA=$(echo "$CHECKSUMS" | grep linux_arm64.tar.gz | awk '{print $1}')
+          
+          # Update version
+          sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/mongo2dynamo.rb
+          
+          # Update SHA256 for each platform
+          sed -i "s/sha256 \".*\" # darwin_amd64/sha256 \"${DARWIN_AMD64_SHA}\" # darwin_amd64/" Formula/mongo2dynamo.rb
+          sed -i "s/sha256 \".*\" # darwin_arm64/sha256 \"${DARWIN_ARM64_SHA}\" # darwin_arm64/" Formula/mongo2dynamo.rb
+          sed -i "s/sha256 \".*\" # linux_amd64/sha256 \"${LINUX_AMD64_SHA}\" # linux_amd64/" Formula/mongo2dynamo.rb
+          sed -i "s/sha256 \".*\" # linux_arm64/sha256 \"${LINUX_ARM64_SHA}\" # linux_arm64/" Formula/mongo2dynamo.rb
+
+      - name: Commit and push if changed
+        run: |
+          cd homebrew-tap
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add Formula/mongo2dynamo.rb
+          git diff --quiet && git diff --staged --quiet || (git commit -m "release: Update mongo2dynamo to ${VERSION}" && git push)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,40 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^style:'
+      - '^misc:'


### PR DESCRIPTION
This pull request introduces automation for the release process and configuration for GoReleaser. The changes include setting up GitHub Actions workflows for releasing and updating Homebrew formulas, as well as defining GoReleaser configurations for builds, archives, and changelogs.

### Release Automation:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR1-R72): Added a GitHub Actions workflow to automate releases triggered by version tags. This includes steps for checking out the repository, setting up Go, running GoReleaser, and updating Homebrew formulas with the latest version and checksums.

### GoReleaser Configuration:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R1-R40): Configured GoReleaser to tidy Go modules before building, define builds for Linux and macOS with `amd64` and `arm64` architectures, specify archive formats, generate checksums, and exclude certain commit types from the changelog.