### PR TITLE
fix: Resolve sed command error in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,14 +62,18 @@ jobs:
           LINUX_AMD64_SHA=$(echo "$CHECKSUMS" | grep mongo2dynamo_Linux_x86_64.tar.gz | awk '{print $1}')
           LINUX_ARM64_SHA=$(echo "$CHECKSUMS" | grep mongo2dynamo_Linux_arm64.tar.gz | awk '{print $1}')
           
-          # Update version
-          sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/mongo2dynamo.rb
+          # Update version and URLs
+          sed -i "s|version \".*\"|version \"$VERSION\"|" Formula/mongo2dynamo.rb
+          sed -i "s|url \".*\"|url \"https://github.com/dutymate/mongo2dynamo/releases/download/v$VERSION/mongo2dynamo_Darwin_x86_64.tar.gz\"|" Formula/mongo2dynamo.rb
+          sed -i "s|url \".*\"|url \"https://github.com/dutymate/mongo2dynamo/releases/download/v$VERSION/mongo2dynamo_Darwin_arm64.tar.gz\"|" Formula/mongo2dynamo.rb
+          sed -i "s|url \".*\"|url \"https://github.com/dutymate/mongo2dynamo/releases/download/v$VERSION/mongo2dynamo_Linux_x86_64.tar.gz\"|" Formula/mongo2dynamo.rb
+          sed -i "s|url \".*\"|url \"https://github.com/dutymate/mongo2dynamo/releases/download/v$VERSION/mongo2dynamo_Linux_arm64.tar.gz\"|" Formula/mongo2dynamo.rb
           
           # Update SHA256 for each platform
-          sed -i "s/sha256 \".*\" # darwin_amd64/sha256 \"${DARWIN_AMD64_SHA}\" # darwin_amd64/" Formula/mongo2dynamo.rb
-          sed -i "s/sha256 \".*\" # darwin_arm64/sha256 \"${DARWIN_ARM64_SHA}\" # darwin_arm64/" Formula/mongo2dynamo.rb
-          sed -i "s/sha256 \".*\" # linux_amd64/sha256 \"${LINUX_AMD64_SHA}\" # linux_amd64/" Formula/mongo2dynamo.rb
-          sed -i "s/sha256 \".*\" # linux_arm64/sha256 \"${LINUX_ARM64_SHA}\" # linux_arm64/" Formula/mongo2dynamo.rb
+          sed -i "s|sha256 \".*\" # darwin_amd64|sha256 \"${DARWIN_AMD64_SHA}\" # darwin_amd64|" Formula/mongo2dynamo.rb
+          sed -i "s|sha256 \".*\" # darwin_arm64|sha256 \"${DARWIN_ARM64_SHA}\" # darwin_arm64|" Formula/mongo2dynamo.rb
+          sed -i "s|sha256 \".*\" # linux_amd64|sha256 \"${LINUX_AMD64_SHA}\" # linux_amd64|" Formula/mongo2dynamo.rb
+          sed -i "s|sha256 \".*\" # linux_arm64|sha256 \"${LINUX_ARM64_SHA}\" # linux_arm64|" Formula/mongo2dynamo.rb
 
       - name: Commit and push if changed
         run: |


### PR DESCRIPTION
This pull request updates the `release.yaml` workflow to enhance the version update process for the `Formula/mongo2dynamo.rb` file. The changes include updating both version numbers and URLs, as well as using a more robust delimiter (`|`) in `sed` commands to avoid conflicts with special characters.

Enhancements to version update and checksum handling:

* Updated `sed` commands to replace both version numbers and URLs for multiple platforms (`Darwin_x86_64`, `Darwin_arm64`, `Linux_x86_64`, `Linux_arm64`) in `Formula/mongo2dynamo.rb`. This ensures that the URLs point to the correct release assets hosted on GitHub.
* Changed the delimiter in `sed` commands from `"` to `|` for better handling of special characters in URLs and SHA256 values. This improves reliability and readability of the script.