### PR TITLE
fix: Fix unterminated address regex error by using consistent quote style

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,26 +70,26 @@ jobs:
           for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
             case $platform in
               darwin_amd64)
-                block='if Hardware::CPU.intel? # darwin_amd64'
+                tag="# darwin_amd64"
                 sha=$DARWIN_AMD64_SHA
                 ;;
               darwin_arm64)
-                block='if Hardware::CPU.arm? # darwin_arm64'
+                tag="# darwin_arm64"
                 sha=$DARWIN_ARM64_SHA
                 ;;
               linux_amd64)
-                block='if Hardware::CPU.intel? # linux_amd64'
+                tag="# linux_amd64"
                 sha=$LINUX_AMD64_SHA
                 ;;
               linux_arm64)
-                block='if Hardware::CPU.arm? # linux_arm64'
+                tag="# linux_arm64"
                 sha=$LINUX_ARM64_SHA
                 ;;
             esac
-            
-            # Update URL and SHA256 for this platform
-            sed -i '/'$block'/,/end/s|url ".*"|url "https://github.com/dutymate/mongo2dynamo/releases/download/v'$VERSION'/mongo2dynamo_'${platform/darwin/Darwin}'_'${platform/linux/Linux}'.tar.gz"|' Formula/mongo2dynamo.rb
-            sed -i '/'$block'/,/end/s|sha256 ".*"|sha256 "'$sha'"|' Formula/mongo2dynamo.rb
+
+            # Update URL and SHA256 for this platform using the comment tag
+            sed -i "/$tag/,/end/s|url \".*\"|url \"https://github.com/dutymate/mongo2dynamo/releases/download/v$VERSION/mongo2dynamo_${platform/darwin/Darwin}_${platform/linux/Linux}.tar.gz\"|" Formula/mongo2dynamo.rb
+            sed -i "/$tag/,/end/s|sha256 \".*\"|sha256 \"$sha\"|" Formula/mongo2dynamo.rb
           done
 
       - name: Commit and push if changed


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yaml` file to simplify platform-specific logic in the release workflow. The most notable change replaces the use of conditional blocks with comment tags for identifying platform-specific sections, streamlining the process of updating URLs and SHA256 checksums.

### Workflow simplification:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL73-R92): Replaced conditional blocks (`if Hardware::CPU.intel?` and `if Hardware::CPU.arm?`) with comment tags (`# darwin_amd64`, `# darwin_arm64`, etc.) to identify platform-specific sections. This simplifies the `sed` commands used to update URLs and SHA256 values for different platforms.