### PR TITLE
fix: Correct homebrew-tap repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command-line tool for migrating data from MongoDB to DynamoDB.
 ### Homebrew
 
 ```bash
-brew tap dutymate/tap
+brew tap dutymate/homebrew-tap
 brew install mongo2dynamo
 ```
 


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file to correct the Homebrew tap command for installing the `mongo2dynamo` tool.