### PR TITLE
chore: Update homebrew formula commit message format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,4 +102,4 @@ jobs:
           git config user.name "Jongwoo Han"
           git config user.email "jongwooo.han@gmail.com"
           git add Formula/mongo2dynamo.rb
-          git diff --quiet && git diff --staged --quiet || (git commit -m "Update mongo2dynamo to v$VERSION" && git push)
+          git diff --quiet && git diff --staged --quiet || (git commit -m "release: Update mongo2dynamo to v$VERSION" && git push)


### PR DESCRIPTION
This pull request makes a minor update to the commit message format in the `.github/workflows/release.yaml` file to improve clarity and consistency.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL105-R105): Updated the commit message prefix from "Update mongo2dynamo to v$VERSION" to "release: Update mongo2dynamo to v$VERSION" for better context in release-related commits.