### PR TITLE
test: Add version command integration test

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -222,4 +223,27 @@ func TestPlanCommand(t *testing.T) {
 
 	// Verify plan output.
 	require.Contains(t, string(output), "Found 1 documents to migrate")
+}
+
+// TestVersionCommand tests the version command functionality.
+func TestVersionCommand(t *testing.T) {
+	// Run the version command.
+	cmd := exec.Command("go", "run", "../../main.go", "version")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "CLI version command should not fail")
+
+	// Verify version output format.
+	outputStr := string(output)
+	require.Contains(t, outputStr, "Version:")
+	require.Contains(t, outputStr, "Git Commit:")
+	require.Contains(t, outputStr, "Build Date:")
+
+	// Verify that the output has the expected structure.
+	lines := strings.Split(strings.TrimSpace(outputStr), "\n")
+	require.Len(t, lines, 3, "Version output should have exactly 3 lines")
+
+	// Verify each line format.
+	require.Regexp(t, `^Version: .+$`, lines[0], "Version line should match expected format")
+	require.Regexp(t, `^Git Commit: .+$`, lines[1], "Git Commit line should match expected format")
+	require.Regexp(t, `^Build Date: .+$`, lines[2], "Build Date line should match expected format")
 }


### PR DESCRIPTION
This pull request adds functionality to test the `version` command in the CLI and includes minor improvements to the `integration_test.go` file.

### New test functionality:

* [`test/integration/integration_test.go`](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bR227-R249): Added `TestVersionCommand` to validate the CLI `version` command output. The test ensures the output includes `Version`, `Git Commit`, and `Build Date` fields, checks their format, and verifies the structure of the output.

### Minor improvements:

* [`test/integration/integration_test.go`](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bR6): Added the `strings` package to the import list to support string manipulation in tests.