### PR TITLE
chore: Add goimports to fmt target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ lint:
 .PHONY: fmt
 fmt:
 	go fmt ./...
+	goimports -w .
 
 # Build the application.
 .PHONY: build


### PR DESCRIPTION
This pull request includes a small change to the `Makefile`. The change updates the `fmt` target to include the `goimports` command for formatting and organizing imports.