### PR TITLE
chore: Expand changelog exclude list for conventional commit prefixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,11 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
-      - '^style:'
-      - '^misc:'
+      - '^chore(?:\(.*\))?:'
+      - '^docs(?:\(.*\))?:'
+      - '^misc(?:\(.*\))?:'
+      - '^perf(?:\(.*\))?:'
+      - '^refactor(?:\(.*\))?:'
+      - '^revert(?:\(.*\))?:'
+      - '^style(?:\(.*\))?:'
+      - '^test(?:\(.*\))?:'


### PR DESCRIPTION
This pull request updates the changelog configuration in `.goreleaser.yml` to refine the filtering of commit messages. The changes expand the excluded commit types to include more specific patterns for better categorization.

Changelog configuration updates:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L44-R51): Updated the `exclude` filters in the `changelog` section to include more detailed patterns for commit types such as `chore`, `docs`, `misc`, `perf`, `refactor`, `revert`, `style`, and `test`. This ensures that these types of commits are excluded from the changelog generation.