### PR TITLE
feat: Add FormatNumber method for comma-separated number formatting

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -23,4 +24,44 @@ func ConfirmWithReader(r io.Reader, prompt string) bool {
 	}
 	text = strings.ToLower(strings.TrimSpace(text))
 	return text == "y" || text == "yes"
+}
+
+// FormatNumber formats an integer with comma separators for thousands.
+func FormatNumber(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+
+	var parts []string
+	for n > 0 {
+		parts = append(parts, strconv.Itoa(n%1000))
+		n /= 1000
+	}
+
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+
+	for i := 1; i < len(parts); i++ {
+		if len(parts[i]) < 3 {
+			parts[i] = strings.Repeat("0", 3-len(parts[i])) + parts[i]
+		}
+	}
+
+	var b strings.Builder
+	if negative {
+		b.WriteByte('-')
+	}
+	for i, part := range parts {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(part)
+	}
+	return b.String()
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -20,3 +20,33 @@ func TestConfirmWithReader_no(t *testing.T) {
 		t.Errorf("expected false, got true")
 	}
 }
+
+func TestFormatNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{"zero", 0, "0"},
+		{"single digit", 5, "5"},
+		{"double digit", 42, "42"},
+		{"triple digit", 123, "123"},
+		{"four digits", 1234, "1,234"},
+		{"five digits", 12345, "12,345"},
+		{"six digits", 123456, "123,456"},
+		{"seven digits", 1234567, "1,234,567"},
+		{"ten digits", 1234567890, "1,234,567,890"},
+		{"negative number", -1234, "-1,234"},
+		{"exact thousand", 1000, "1,000"},
+		{"exact million", 1000000, "1,000,000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatNumber(tt.input)
+			if result != tt.expected {
+				t.Errorf("FormatNumber(%d) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/migrator/service.go
+++ b/pkg/migrator/service.go
@@ -29,7 +29,7 @@ func (s *Service) Run(ctx context.Context) error {
 		return &common.MigrationStepError{Step: "read", Reason: err.Error(), Err: err}
 	}
 
-	fmt.Printf("Found %d documents to migrate\n", len(data))
+	fmt.Printf("Found %s documents to migrate\n", common.FormatNumber(len(data)))
 
 	if s.dryRun {
 		return nil
@@ -39,6 +39,6 @@ func (s *Service) Run(ctx context.Context) error {
 		return &common.MigrationStepError{Step: "write", Reason: err.Error(), Err: err}
 	}
 
-	fmt.Printf("Successfully migrated %d documents\n", len(data))
+	fmt.Printf("Successfully migrated %s documents\n", common.FormatNumber(len(data)))
 	return nil
 }


### PR DESCRIPTION
This pull request introduces a utility function to format numbers with comma separators for better readability and integrates it into the codebase. It also includes corresponding unit tests to ensure the function works as expected. Below are the key changes:

### New Utility Function
* Added `FormatNumber` function in `pkg/common/utils.go` to format integers with comma separators for thousands. It supports both positive and negative numbers.

### Unit Tests
* Added `TestFormatNumber` in `pkg/common/utils_test.go` to validate the `FormatNumber` function with various test cases, including edge cases like zero, negative numbers, and large values.

### Integration into Existing Code
* Updated `pkg/migrator/service.go` to use `FormatNumber` for displaying the count of documents to migrate and successfully migrated documents, improving output readability. [[1]](diffhunk://#diff-48a058fc5823a35a8535debc4edc3e1a960ca8502bb2ce2754d4cc71fe21d543L32-R32) [[2]](diffhunk://#diff-48a058fc5823a35a8535debc4edc3e1a960ca8502bb2ce2754d4cc71fe21d543L42-R42)

### Import Updates
* Added `strconv` to the imports in `pkg/common/utils.go` to support the new `FormatNumber` function.