### PR TITLE
refactor: Align DataValidationError fields with other error types

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -69,16 +69,17 @@ func (e *MigrationStepError) Unwrap() error {
 
 // DataValidationError is returned for data validation errors not related to config.
 type DataValidationError struct {
-	Field  string
-	Reason string
-	Err    error
+	Database string
+	Op       string
+	Reason   string
+	Err      error
 }
 
 func (e *DataValidationError) Error() string {
 	if e.Err != nil {
-		return fmt.Sprintf("data validation error on field '%s': %s: %v", e.Field, e.Reason, e.Err)
+		return fmt.Sprintf("data validation error on '%s' (%s): %s: %v", e.Database, e.Op, e.Reason, e.Err)
 	}
-	return fmt.Sprintf("data validation error on field '%s': %s", e.Field, e.Reason)
+	return fmt.Sprintf("data validation error on '%s' (%s): %s", e.Database, e.Op, e.Reason)
 }
 
 func (e *DataValidationError) Unwrap() error {

--- a/pkg/dynamo/writer.go
+++ b/pkg/dynamo/writer.go
@@ -36,7 +36,12 @@ func (w *Writer) Write(ctx context.Context, data []map[string]interface{}) error
 	for _, item := range data {
 		av, err := attributevalue.MarshalMap(item)
 		if err != nil {
-			return &common.DataValidationError{Field: "dynamo marshal", Reason: err.Error(), Err: err}
+			return &common.DataValidationError{
+				Database: "DynamoDB",
+				Op:       "marshal",
+				Reason:   err.Error(),
+				Err:      err,
+			}
 		}
 		writeRequests = append(writeRequests, types.WriteRequest{
 			PutRequest: &types.PutRequest{

--- a/pkg/mongo/reader.go
+++ b/pkg/mongo/reader.go
@@ -41,7 +41,12 @@ func (r *Reader) Read(ctx context.Context) ([]map[string]interface{}, error) {
 	for cursor.Next(ctx) {
 		var doc map[string]interface{}
 		if err := cursor.Decode(&doc); err != nil {
-			return nil, &common.DataValidationError{Field: "mongo decode", Reason: err.Error(), Err: err}
+			return nil, &common.DataValidationError{
+				Database: "MongoDB",
+				Op:       "decode",
+				Reason:   err.Error(),
+				Err:      err,
+			}
 		}
 
 		documents = append(documents, doc)


### PR DESCRIPTION
This pull request refactors the `DataValidationError` structure to improve error clarity and consistency by replacing the `Field` attribute with `Database` and `Op` attributes. Additionally, it updates error handling in related methods to reflect this change.

### Refactoring of `DataValidationError`:

* [`pkg/common/errors.go`](diffhunk://#diff-c41a146cfaaaff1dcfbd74bb71c443615b15887e1844b56375fa46a263826d68L72-R82): Replaced the `Field` attribute in the `DataValidationError` struct with `Database` (to specify the database type) and `Op` (to indicate the operation being performed). Updated the `Error()` method to include these new attributes in the error message.

### Updates to error handling in database operations:

* [`pkg/dynamo/writer.go`](diffhunk://#diff-09e72c2b738c24a4eaf6718e5e328ae9705c3e7b4bddb7f50d934765d0fa7c52L39-R44): Updated the `Write` method to use the refactored `DataValidationError` structure, specifying `Database` as "DynamoDB" and `Op` as "marshal" for marshalling errors.
* [`pkg/mongo/reader.go`](diffhunk://#diff-1fb129599edd5c09b3e142ca6693af60a636fab0705e55df4211bae37c824778L44-R49): Updated the `Read` method to use the refactored `DataValidationError` structure, specifying `Database` as "MongoDB" and `Op` as "decode" for decoding errors.