### PR TITLE
feat: Robust mongo authentication error detection and error context

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -106,16 +106,17 @@ func (e *FileIOError) Unwrap() error {
 
 // AuthError is returned for authentication/authorization errors.
 type AuthError struct {
-	Op     string
-	Reason string
-	Err    error
+	Database string
+	Op       string
+	Reason   string
+	Err      error
 }
 
 func (e *AuthError) Error() string {
 	if e.Err != nil {
-		return fmt.Sprintf("authentication/authorization error during '%s': %s: %v", e.Op, e.Reason, e.Err)
+		return fmt.Sprintf("authentication/authorization error on '%s' (%s): %s: %v", e.Database, e.Op, e.Reason, e.Err)
 	}
-	return fmt.Sprintf("authentication/authorization error during '%s': %s", e.Op, e.Reason)
+	return fmt.Sprintf("authentication/authorization error on '%s' (%s): %s", e.Database, e.Op, e.Reason)
 }
 
 func (e *AuthError) Unwrap() error {

--- a/pkg/mongo/mongo.go
+++ b/pkg/mongo/mongo.go
@@ -2,6 +2,9 @@ package mongo
 
 import (
 	"context"
+	"errors"
+	"strings"
+
 	"mongo2dynamo/pkg/common"
 	"mongo2dynamo/pkg/config"
 
@@ -9,18 +12,105 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// mongoAuthErrorPatterns contains common authentication failure patterns for MongoDB errors.
+var mongoAuthErrorPatterns = []string{
+	"authentication failed",
+	"auth failed",
+	"unauthorized",
+	"invalid credentials",
+	"authentication error",
+	"sasl authentication",
+	"bad auth",
+	"auth source",
+	"authentication mechanism",
+}
+
 // Connect establishes a connection to MongoDB.
 func Connect(ctx context.Context, cfg *config.Config) (*mongo.Client, error) {
 	clientOpts := options.Client().ApplyURI(cfg.GetMongoURI())
+
+	// Explicitly set authentication credentials if provided.
+	if cfg.MongoUser != "" && cfg.MongoPassword != "" {
+		clientOpts.SetAuth(options.Credential{
+			Username: cfg.MongoUser,
+			Password: cfg.MongoPassword,
+		})
+	}
+
 	client, err := mongo.Connect(ctx, clientOpts)
 	if err != nil {
+		if isMongoAuthError(err) {
+			return nil, &common.AuthError{
+				Database: "MongoDB",
+				Op:       "connect",
+				Reason:   err.Error(),
+				Err:      err,
+			}
+		}
 		return nil, &common.DatabaseConnectionError{Database: "MongoDB", Reason: err.Error(), Err: err}
 	}
 
 	// Ping the database to verify connection.
 	if err := client.Ping(ctx, nil); err != nil {
+		// Disconnect the client to avoid resource leaks.
+		_ = client.Disconnect(ctx)
+		if isMongoAuthError(err) {
+			return nil, &common.AuthError{
+				Database: "MongoDB",
+				Op:       "ping",
+				Reason:   err.Error(),
+				Err:      err,
+			}
+		}
 		return nil, &common.DatabaseConnectionError{Database: "MongoDB", Reason: err.Error(), Err: err}
 	}
 
 	return client, nil
+}
+
+// isMongoAuthError checks if the error is related to MongoDB authentication failure.
+func isMongoAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for CommandError type.
+	var cmdErr mongo.CommandError
+	if errors.As(err, &cmdErr) {
+		return isAuthErrorCode(cmdErr.Code)
+	}
+
+	// Check for WriteException type.
+	var writeErr mongo.WriteException
+	if errors.As(err, &writeErr) {
+		for _, we := range writeErr.WriteErrors {
+			if isAuthErrorCode(int32(we.Code)) {
+				return true
+			}
+		}
+	}
+
+	// Fallback to string pattern matching.
+	return containsAuthErrorPattern(err.Error())
+}
+
+// isAuthErrorCode returns true if the code is a known MongoDB auth error code.
+func isAuthErrorCode(code int32) bool {
+	switch code {
+	case 13, 18, 334, 35: // Unauthorized(13), AuthenticationFailed(18), MechanismUnavailable(334), IllegalOperation(35).
+		return true
+	default:
+		return false
+	}
+}
+
+// containsAuthErrorPattern checks if the error message contains any authentication failure patterns.
+func containsAuthErrorPattern(errMsg string) bool {
+	errMsg = strings.ToLower(errMsg)
+	for _, pattern := range mongoAuthErrorPatterns {
+		if strings.Contains(errMsg, pattern) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This pull request introduces improvements to error handling for MongoDB authentication errors and enhances the `AuthError` struct for better context in error messages. The changes include adding detailed checks for MongoDB authentication errors and updating the error formatting to include the database name.

### Enhancements to MongoDB authentication error handling:
* Added `isMongoAuthError` function to detect MongoDB authentication errors using error codes, types (`CommandError`, `WriteException`), and string pattern matching.
* Introduced `mongoAuthErrorPatterns` to store common authentication failure patterns for string-based error detection.
* Updated the `Connect` function to return a more descriptive `AuthError` when authentication errors occur during connection or ping operations.

### Improvements to `AuthError` struct:
* Added a new `Database` field to the `AuthError` struct to specify the database associated with the error.
* Updated the `Error` method of `AuthError` to include the database name in the error message for better clarity.