### PR TITLE
docs: Clarify that dry-run is a command mode in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Download the latest release from the [releases page](https://github.com/dutymate
 - Migrate data from MongoDB to DynamoDB
 - Support for MongoDB authentication
 - Support for local DynamoDB
-- Dry run mode for testing
 - Auto-approve option for automation
 
 ## Usage
@@ -70,7 +69,6 @@ mongo2dynamo apply \
 | `--dynamo-table` | DynamoDB table name | Yes* | - |
 | `--aws-region` | AWS region | No | us-east-1 |
 | `--auto-approve` | Skip confirmation prompt | No | false |
-| `--dry-run` | Show what would be migrated without actually migrating | No | false |
 
 ## Environment Variables
 


### PR DESCRIPTION
This pull request updates the `README.md` file to remove references to the "dry run" mode, which is no longer supported. The changes ensure the documentation accurately reflects the current functionality of the project.

Documentation updates:

* Removed the mention of "dry run mode for testing" from the feature list in the `README.md` file.
* Removed the `--dry-run` option from the command-line arguments table in the `README.md` file.