### PR TITLE
chore: Update goreleaser pre-build hook to use `make deps`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 before:
   hooks:
-    - go mod tidy
+    - make deps
 
 builds:
   - env:


### PR DESCRIPTION
This pull request updates the `.goreleaser.yml` configuration to improve dependency management during the build process.

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L3-R3): Replaced the `go mod tidy` hook with `make deps` in the `before` section to standardize dependency installation and preparation.