### PR TITLE
test(flags): Add unit tests for flags

### DIFF
--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -1,0 +1,51 @@
+package flags_test
+
+import (
+	"testing"
+
+	"mongo2dynamo/pkg/flags"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddMongoFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	flags.AddMongoFlags(cmd)
+
+	hostFlag := cmd.Flags().Lookup("mongo-host")
+	assert.NotNil(t, hostFlag, "mongo-host flag should be registered")
+	assert.Equal(t, "localhost", hostFlag.DefValue)
+
+	portFlag := cmd.Flags().Lookup("mongo-port")
+	assert.NotNil(t, portFlag, "mongo-port flag should be registered")
+	assert.Equal(t, "27017", portFlag.DefValue)
+
+	userFlag := cmd.Flags().Lookup("mongo-user")
+	assert.NotNil(t, userFlag, "mongo-user flag should be registered")
+
+	passwordFlag := cmd.Flags().Lookup("mongo-password")
+	assert.NotNil(t, passwordFlag, "mongo-password flag should be registered")
+
+	dbFlag := cmd.Flags().Lookup("mongo-db")
+	assert.NotNil(t, dbFlag, "mongo-db flag should be registered")
+
+	collectionFlag := cmd.Flags().Lookup("mongo-collection")
+	assert.NotNil(t, collectionFlag, "mongo-collection flag should be registered")
+}
+
+func TestAddDynamoFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	flags.AddDynamoFlags(cmd)
+
+	endpointFlag := cmd.Flags().Lookup("dynamo-endpoint")
+	assert.NotNil(t, endpointFlag, "dynamo-endpoint flag should be registered")
+	assert.Equal(t, "http://localhost:8000", endpointFlag.DefValue)
+
+	tableFlag := cmd.Flags().Lookup("dynamo-table")
+	assert.NotNil(t, tableFlag, "dynamo-table flag should be registered")
+
+	regionFlag := cmd.Flags().Lookup("aws-region")
+	assert.NotNil(t, regionFlag, "aws-region flag should be registered")
+	assert.Equal(t, "us-east-1", regionFlag.DefValue)
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the `AddMongoFlags` and `AddDynamoFlags` functions in the `pkg/flags` package. These tests ensure that the expected command-line flags are correctly registered with their default values.

### Added unit tests for flag registration:

* [`pkg/flags/flags_test.go`](diffhunk://#diff-199c774ef105a055a3cb32be369faad14d454e5aebd8e9a0c43b14a311c43895R1-R51): Added `TestAddMongoFlags` to verify that the `mongo-host`, `mongo-port`, `mongo-user`, `mongo-password`, `mongo-db`, and `mongo-collection` flags are registered with the correct default values where applicable.
* [`pkg/flags/flags_test.go`](diffhunk://#diff-199c774ef105a055a3cb32be369faad14d454e5aebd8e9a0c43b14a311c43895R1-R51): Added `TestAddDynamoFlags` to verify that the `dynamo-endpoint`, `dynamo-table`, and `aws-region` flags are registered with the correct default values where applicable.