### PR TITLE
test(version): Add unit tests for version

### DIFF
--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetVersionInfo(t *testing.T) {
+	result := GetVersionInfo()
+
+	// Check that the result contains expected fields.
+	expectedFields := []string{
+		"Version:",
+		"Git Commit:",
+		"Build Date:",
+	}
+
+	for _, field := range expectedFields {
+		if !strings.Contains(result, field) {
+			t.Errorf("GetVersionInfo() should contain '%s'", field)
+		}
+	}
+
+	// Check that the result has the expected format (3 lines).
+	lines := strings.Split(strings.TrimSpace(result), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("GetVersionInfo() should return 3 lines, got %d", len(lines))
+	}
+
+	// Check that each line has the expected format.
+	for i, line := range lines {
+		if !strings.Contains(line, ": ") {
+			t.Errorf("Line %d should contain ': ', got '%s'", i+1, line)
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new test to validate the output of the `GetVersionInfo` function in the `version` package. The test ensures that the function's output contains specific expected fields and adheres to the correct format.

### Added test for `GetVersionInfo`:

* [`pkg/version/version_test.go`](diffhunk://#diff-e59ae4cd1de77749019488d1dda9377ac3487212cac13b97a5ed145083f261dbR1-R36): Added a unit test `TestGetVersionInfo` to verify that the output of `GetVersionInfo` includes the fields "Version:", "Git Commit:", and "Build Date:". The test also checks that the output consists of exactly three lines and that each line contains the separator `": "`.