### PR TITLE
fix: Pin golangci-lint version to v2.1.6

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,4 +21,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1.6


### PR DESCRIPTION
This pull request fixes CI lint failures by pinning golangci-lint to a stable version.

**Issue**
CI started failing with golangci-lint v2.2.1 due to stricter package naming rules for test files.

**Fix**
- Pin golangci-lint version to v2.1.6 in CI workflow
- Ensures consistent lint behavior between local and CI environments