### PR TITLE
test(utils): Add fuzz test for FormatNumber function

### DIFF
--- a/internal/common/utils_fuzz_test.go
+++ b/internal/common/utils_fuzz_test.go
@@ -1,0 +1,20 @@
+package common
+
+import "testing"
+
+func FuzzFormatNumber(f *testing.F) {
+	// Seed corpus with various representative values.
+	f.Add(0)
+	f.Add(1)
+	f.Add(-1)
+	f.Add(100)
+	f.Add(-100)
+	f.Add(1000000)
+	f.Add(-1000000)
+	f.Add(int(^uint(0) >> 1))    // max int.
+	f.Add(-int(^uint(0)>>1) - 1) // min int.
+
+	f.Fuzz(func(_ *testing.T, n int) {
+		_ = FormatNumber(n)
+	})
+}


### PR DESCRIPTION
This pull request adds a fuzz test for the `FormatNumber` function in the `internal/common/utils_fuzz_test.go` file. This test ensures the function is robust against a wide range of integer inputs.

Testing improvements:

* [`internal/common/utils_fuzz_test.go`](diffhunk://#diff-d65b72ec2b8f3e77bac25f84ef55ba313f6c5cf443eb1afd8e55b44e6d6a7c77R1-R20): Introduced a fuzz test for the `FormatNumber` function, seeding it with representative integer values, including edge cases like maximum and minimum integers.