### PR TITLE
refactor: Explicit error wrapping for mongo read

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -1,6 +1,7 @@
 package apply
 
 import (
+	"errors"
 	"fmt"
 	"mongo2dynamo/internal/common"
 	"mongo2dynamo/internal/config"
@@ -76,6 +77,14 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		return nil
 	})
 	if err != nil {
+		var transformErr *common.TransformError
+		var writerErr *common.WriterError
+		if errors.As(err, &transformErr) {
+			return transformErr
+		}
+		if errors.As(err, &writerErr) {
+			return writerErr
+		}
 		return &common.ReaderError{Reason: "failed to read from mongo", Err: err}
 	}
 	fmt.Printf("Successfully migrated %d documents\n", migrated)

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"errors"
 	"fmt"
 	"mongo2dynamo/internal/common"
 	"mongo2dynamo/internal/config"
@@ -59,6 +60,10 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 		return nil
 	})
 	if err != nil {
+		var transformErr *common.TransformError
+		if errors.As(err, &transformErr) {
+			return transformErr
+		}
 		return &common.ReaderError{Reason: "failed to read from mongo", Err: err}
 	}
 	fmt.Printf("Found %d documents to migrate\n", total)


### PR DESCRIPTION
This pull request improves error handling in the `apply` and `plan` commands by introducing more specific error types and updating the error propagation logic.

### Error Handling Improvements:

* [`cmd/apply/apply.go`](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR80-R87): Added checks for `TransformError` and `WriterError` using `errors.As` in the `runApply` function. These errors are now returned directly if encountered, providing more granular error feedback.
* [`cmd/plan/plan.go`](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R63-R66): Added a check for `TransformError` using `errors.As` in the `runPlan` function, allowing the error to be returned directly for better error specificity.

### Dependency Updates:

* `cmd/apply/apply.go` and `cmd/plan/plan.go`: Imported the `errors` package to enable the use of `errors.As` for type assertion in error handling. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR4) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R4)