### PR TITLE
chore: Exclude only dependency update commits from changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,11 +41,4 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - '^chore(?:\(.*\))?:'
-      - '^docs(?:\(.*\))?:'
-      - '^misc(?:\(.*\))?:'
-      - '^perf(?:\(.*\))?:'
-      - '^refactor(?:\(.*\))?:'
-      - '^revert(?:\(.*\))?:'
-      - '^style(?:\(.*\))?:'
-      - '^test(?:\(.*\))?:'
+      - "^chore\\(deps\\):"


### PR DESCRIPTION
This pull request makes a minor adjustment to the changelog configuration in `.goreleaser.yml`, refining the filtering rules for excluded commit messages.

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L44-R44): Updated the `changelog` filters to exclude only commit messages matching `^chore\(deps\):` instead of the broader set of patterns previously excluded.