### PR TITLE
perf(transformer): Parallelize Transform function using worker pool

### DIFF
--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -1,8 +1,16 @@
 package transformer
 
+import (
+	"fmt"
+	"mongo2dynamo/internal/common"
+	"runtime"
+	"sync"
+)
+
 // Transformer provides an interface for transforming documents between formats.
 type Transformer interface {
 	// Transform returns a new slice of documents with the transformation applied.
+	// Returns an error if transformation fails.
 	Transform([]map[string]interface{}) ([]map[string]interface{}, error)
 }
 
@@ -28,30 +36,79 @@ func NewMongoToDynamoTransformer() *MongoToDynamoTransformer {
 // The '_class' field, which is used by Spring Data for type information, is also omitted from the output.
 // The resulting slice contains documents ready to be written to DynamoDB, with no '_id', '__v', or '_class' fields present.
 // Returns an error only if an unexpected issue occurs during transformation (none in current implementation).
+// This function uses a worker pool to parallelize transformation for better performance on large batches.
 func (t *MongoToDynamoTransformer) Transform(input []map[string]interface{}) ([]map[string]interface{}, error) {
 	output := make([]map[string]interface{}, len(input))
+	if len(input) == 0 {
+		return output, nil
+	}
+
+	numWorkers := min(runtime.NumCPU(), len(input)) // Number of workers is capped to the number of jobs.
+	type job struct {
+		idx int
+		doc map[string]interface{}
+	}
+	jobs := make(chan job, len(input))
+	errChan := make(chan error, numWorkers) // Channel to collect errors from workers.
+	var wg sync.WaitGroup
+	worker := func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				errChan <- &common.TransformError{
+					Reason: fmt.Sprintf("worker panic during document transformation: %v", r),
+					Err:    fmt.Errorf("panic: %v", r),
+				}
+			}
+		}()
+		for j := range jobs {
+			doc := j.doc
+			// Count the number of fields to keep (including id).
+			kept := 0
+			for k := range doc {
+				if k == "_id" {
+					continue
+				}
+				if _, skip := skipFields[k]; skip {
+					continue
+				}
+				kept++
+			}
+			// Create a new document with the kept fields and id.
+			newDoc := make(map[string]interface{}, kept+1)
+			for k, v := range doc {
+				if k == "_id" {
+					newDoc["id"] = v
+					continue
+				}
+				if _, skip := skipFields[k]; skip {
+					continue
+				}
+				newDoc[k] = v
+			}
+			output[j.idx] = newDoc
+		}
+	}
+
+	// Start the worker pool.
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+	// Distribute jobs to workers.
 	for i, doc := range input {
-		// Calculate the exact number of kept fields (including id).
-		kept := 0
-		for k := range doc {
-			if k == "_id" || skipFields[k] == struct{}{} {
-				continue
-			}
-			kept++
+		jobs <- job{idx: i, doc: doc}
+	}
+	close(jobs)
+
+	wg.Wait()
+	close(errChan)
+	// Return the first error encountered by any worker, if present.
+	for err := range errChan {
+		if err != nil {
+			return nil, err
 		}
-		// Include the id field.
-		newDoc := make(map[string]interface{}, kept+1)
-		for k, v := range doc {
-			if k == "_id" {
-				newDoc["id"] = v
-				continue
-			}
-			if _, skip := skipFields[k]; skip {
-				continue
-			}
-			newDoc[k] = v
-		}
-		output[i] = newDoc
 	}
 	return output, nil
 }

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -72,3 +72,15 @@ func TestMongoToDynamoTransformer_Transform(t *testing.T) {
 		}
 	}
 }
+
+func TestMongoToDynamoTransformer_Transform_EmptyInput(t *testing.T) {
+	trans := NewMongoToDynamoTransformer()
+	input := []map[string]interface{}{}
+	output, err := trans.Transform(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(output) != 0 {
+		t.Errorf("expected output length 0, got %d", len(output))
+	}
+}

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -1,8 +1,10 @@
 package transformer
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestMongoToDynamoTransformer_Transform(t *testing.T) {
@@ -15,22 +17,58 @@ func TestMongoToDynamoTransformer_Transform(t *testing.T) {
 		{"id": "abc123", "name": "test"},
 		{"id": "def456", "name": "test2", "other": 42},
 	}
-	output, err := trans.Transform(input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(expected, output) {
-		t.Errorf("expected output to equal expected, got %v", output)
-	}
-	for _, doc := range output {
-		if _, exists := doc["_id"]; exists {
-			t.Errorf("_id should not be present in output: %v", doc)
+
+	// Run the test multiple times with shuffled input to check for race conditions and order preservation.
+	runs := 10
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < runs; i++ {
+		shuffled := make([]map[string]interface{}, len(input))
+		copy(shuffled, input)
+		// Shuffle the input slice using the local random generator.
+		for j := range shuffled {
+			k := r.Intn(j + 1)
+			shuffled[j], shuffled[k] = shuffled[k], shuffled[j]
 		}
-		if _, exists := doc["_class"]; exists {
-			t.Errorf("_class should not be present in output: %v", doc)
+		output, err := trans.Transform(shuffled)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-		if _, exists := doc["__v"]; exists {
-			t.Errorf("__v should not be present in output: %v", doc)
+		// The output must have the same length as the input.
+		if len(output) != len(shuffled) {
+			t.Errorf("expected output length %d, got %d", len(shuffled), len(output))
+		}
+		// The order of output must match the input: input _id and output id must be equal at each index.
+		for idx, doc := range output {
+			inID := shuffled[idx]["_id"]
+			outID := doc["id"]
+			if inID != outID {
+				t.Errorf("at idx %d: expected id %v, got %v", idx, inID, outID)
+			}
+		}
+		// Check that all expected documents are present in the output, regardless of order.
+		for _, want := range expected {
+			found := false
+			for _, got := range output {
+				if reflect.DeepEqual(want, got) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected document %+v not found in output", want)
+			}
+			// Check that no forbidden fields are present in the output.
+			for _, doc := range output {
+				if _, exists := doc["_id"]; exists {
+					t.Errorf("_id should not be present in output: %v", doc)
+				}
+				if _, exists := doc["_class"]; exists {
+					t.Errorf("_class should not be present in output: %v", doc)
+				}
+				if _, exists := doc["__v"]; exists {
+					t.Errorf("__v should not be present in output: %v", doc)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `MongoToDynamoTransformer` functionality, including performance improvements through parallelized processing, better error handling, and expanded test coverage. The most important changes involve implementing a worker pool for transformation, adding error recovery for worker panics, and updating the test suite to validate race conditions and edge cases.

### Transformer Enhancements:

* **Parallelized Transformation**: The `Transform` method now uses a worker pool to parallelize document processing, improving performance for large batches. The number of workers is dynamically determined based on the number of CPUs and input size. [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R39-R77) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L54-R111)
* **Error Handling**: Added error recovery for worker panics using a `defer` statement and a custom `TransformError` type to ensure robustness during transformation.

### Test Suite Improvements:

* **Race Condition Testing**: The `TestMongoToDynamoTransformer_Transform` test now runs multiple iterations with shuffled input to verify order preservation and detect potential race conditions.
* **Edge Case Testing**: Added a new test case, `TestMongoToDynamoTransformer_Transform_EmptyInput`, to ensure the transformer correctly handles empty input without errors.

### Code Updates:

* **Imports**: Introduced new imports, including `sync`, `runtime`, and `mongo2dynamo/internal/common`, to support parallelization and error handling.