### PR TITLE
refactor: Apply consistent ETL naming across all components

### DIFF
--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -40,18 +40,18 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Create dataExtractor using configuration.
-	dataExtractor, err := extractor.NewDataExtractor(cmd.Context(), cfg)
+	// Create mongoExtractor using configuration.
+	mongoExtractor, err := extractor.NewMongoExtractor(cmd.Context(), cfg)
 	if err != nil {
 		return &common.ExtractError{Reason: "failed to create extractor", Err: err}
 	}
 
-	// Create dataTransformer for MongoDB to DynamoDB document conversion.
-	dataTransformer := transformer.NewMongoToDynamoTransformer()
+	// Create docTransformer for MongoDB to DynamoDB document conversion.
+	docTransformer := transformer.NewDocTransformer()
 	total := 0
-	err = dataExtractor.Extract(cmd.Context(), func(chunk []map[string]interface{}) error {
+	err = mongoExtractor.Extract(cmd.Context(), func(chunk []map[string]interface{}) error {
 		// Apply transformation.
-		transformed, err := dataTransformer.Transform(chunk)
+		transformed, err := docTransformer.Transform(chunk)
 		if err != nil {
 			return &common.TransformError{Reason: "failed to transform chunk", Err: err}
 		}

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -4,14 +4,19 @@ import (
 	"context"
 )
 
-// DataExtractor defines the interface for extracting data from a source.
-type DataExtractor interface {
+// Extractor defines the interface for extracting data from a source.
+type Extractor interface {
 	// Extract retrieves data from the source and processes it chunk by chunk using the provided callback.
 	Extract(ctx context.Context, handleChunk func([]map[string]interface{}) error) error
 }
 
-// DataLoader defines the interface for loading data to a destination.
-type DataLoader interface {
+// Transformer defines the interface for transforming data between formats.
+type Transformer interface {
+	Transform([]map[string]interface{}) ([]map[string]interface{}, error)
+}
+
+// Loader defines the interface for loading data to a destination.
+type Loader interface {
 	// Load saves the provided data to the destination.
 	// Returns any error that occurred during the load operation.
 	Load(ctx context.Context, data []map[string]interface{}) error

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -24,16 +24,16 @@ type Cursor interface {
 	Err() error
 }
 
-// Extractor implements the DataExtractor interface for MongoDB.
-type Extractor struct {
+// MongoExtractor implements the Extractor interface for MongoDB.
+type MongoExtractor struct {
 	collection Collection
 	batchSize  int // Number of documents to fetch from MongoDB per batch.
 	chunkSize  int // Number of documents to pass to handleChunk per chunk.
 }
 
-// newExtractor creates a new MongoDB extractor with the specified collection, batchSize, and chunkSize.
-func newExtractor(collection Collection) *Extractor {
-	return &Extractor{
+// newMongoExtractor creates a new MongoDB extractor with the specified collection, batchSize, and chunkSize.
+func newMongoExtractor(collection Collection) *MongoExtractor {
+	return &MongoExtractor{
 		collection: collection,
 		batchSize:  500,
 		chunkSize:  1000,
@@ -41,7 +41,7 @@ func newExtractor(collection Collection) *Extractor {
 }
 
 // Extract retrieves documents from the MongoDB collection in fixed-size chunks and processes them using the provided callback.
-func (e *Extractor) Extract(ctx context.Context, handleChunk func([]map[string]interface{}) error) error {
+func (e *MongoExtractor) Extract(ctx context.Context, handleChunk func([]map[string]interface{}) error) error {
 	findOptions := options.Find().SetBatchSize(int32(e.batchSize))
 	cursor, err := e.collection.Find(ctx, bson.M{}, findOptions)
 	if err != nil {
@@ -83,14 +83,14 @@ func (e *Extractor) Extract(ctx context.Context, handleChunk func([]map[string]i
 	return nil
 }
 
-// NewDataExtractor creates a DataExtractor for MongoDB based on the configuration.
-func NewDataExtractor(ctx context.Context, cfg *config.Config) (common.DataExtractor, error) {
+// NewMongoExtractor creates a MongoExtractor for MongoDB based on the configuration.
+func NewMongoExtractor(ctx context.Context, cfg *config.Config) (common.Extractor, error) {
 	client, err := mongo.Connect(ctx, cfg)
 	if err != nil {
 		return nil, &common.DatabaseConnectionError{Database: "MongoDB", Reason: err.Error(), Err: err}
 	}
 	collection := client.Database(cfg.MongoDB).Collection(cfg.MongoCollection)
-	return newExtractor(&mongoCollectionWrapper{collection}), nil
+	return newMongoExtractor(&mongoCollectionWrapper{collection}), nil
 }
 
 // mongoCollectionWrapper wraps *mongo.Collection to implement Collection interface.

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -82,7 +82,7 @@ func (m *MockCursor) Err() error {
 	return fmt.Errorf("mock Err error: %w", args.Error(0))
 }
 
-func TestExtractor_Extract_EmptyCollection(t *testing.T) {
+func TestMongoExtractor_Extract_EmptyCollection(t *testing.T) {
 	mockCollection := new(MockCollection)
 	mockCursor := &MockCursor{
 		docs: []map[string]interface{}{},
@@ -91,10 +91,10 @@ func TestExtractor_Extract_EmptyCollection(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	extractor := newExtractor(mockCollection)
+	mongoExtractor := newMongoExtractor(mockCollection)
 	var processedDocs []map[string]interface{}
 
-	err := extractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
+	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
 		processedDocs = append(processedDocs, chunk...)
 		return nil
 	})
@@ -118,10 +118,10 @@ func TestExtractor_Extract_SingleChunk(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	extractor := newExtractor(mockCollection)
+	mongoExtractor := newMongoExtractor(mockCollection)
 	var processedDocs []map[string]interface{}
 
-	err := extractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
+	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
 		processedDocs = append(processedDocs, chunk...)
 		return nil
 	})
@@ -148,11 +148,11 @@ func TestExtractor_Extract_MultipleChunks(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	extractor := newExtractor(mockCollection)
+	mongoExtractor := newMongoExtractor(mockCollection)
 	var processedDocs []map[string]interface{}
 	chunkCount := 0
 
-	err := extractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
+	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
 		processedDocs = append(processedDocs, chunk...)
 		chunkCount++
 		return nil
@@ -170,8 +170,8 @@ func TestExtractor_Extract_FindError(t *testing.T) {
 	expectedErr := errors.New("find error")
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
 
-	extractor := newExtractor(mockCollection)
-	err := extractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
+	mongoExtractor := newMongoExtractor(mockCollection)
+	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
 	})
 
@@ -192,9 +192,9 @@ func TestExtractor_Extract_DecodeError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockColl.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	extractor := newExtractor(mockColl)
+	mongoExtractor := newMongoExtractor(mockColl)
 
-	err := extractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
+	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
 	})
 
@@ -219,10 +219,10 @@ func TestExtractor_Extract_CallbackError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	extractor := newExtractor(mockCollection)
+	mongoExtractor := newMongoExtractor(mockCollection)
 	expectedErr := errors.New("callback error")
 
-	err := extractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
+	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return expectedErr
 	})
 
@@ -245,8 +245,8 @@ func TestExtractor_Extract_CursorError(t *testing.T) {
 	mockCursor.On("Err").Return(expectedErr)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	extractor := newExtractor(mockCollection)
-	err := extractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
+	mongoExtractor := newMongoExtractor(mockCollection)
+	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
 	})
 

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -7,16 +7,9 @@ import (
 	"sync"
 )
 
-// Transformer provides an interface for transforming documents between formats.
-type Transformer interface {
-	// Transform returns a new slice of documents with the transformation applied.
-	// Returns an error if transformation fails.
-	Transform([]map[string]interface{}) ([]map[string]interface{}, error)
-}
-
-// MongoToDynamoTransformer transforms MongoDB documents for DynamoDB.
+// DocTransformer transforms MongoDB documents for DynamoDB.
 // It renames the '_id' field to 'id' and removes the '__v' and '_class' fields.
-type MongoToDynamoTransformer struct{}
+type DocTransformer struct{}
 
 // skipFields lists field names to be excluded from the output.
 var skipFields = map[string]struct{}{
@@ -24,10 +17,10 @@ var skipFields = map[string]struct{}{
 	"_class": {},
 }
 
-// NewMongoToDynamoTransformer returns a new MongoToDynamoTransformer.
+// NewDocTransformer returns a new DocTransformer.
 // This transformer can be used to convert MongoDB documents to a DynamoDB-compatible format.
-func NewMongoToDynamoTransformer() *MongoToDynamoTransformer {
-	return &MongoToDynamoTransformer{}
+func NewDocTransformer() *DocTransformer {
+	return &DocTransformer{}
 }
 
 // Transform renames the '_id' field to 'id' and removes the '__v' and '_class' fields from each document.
@@ -37,7 +30,7 @@ func NewMongoToDynamoTransformer() *MongoToDynamoTransformer {
 // The resulting slice contains documents ready to be written to DynamoDB, with no '_id', '__v', or '_class' fields present.
 // Returns an error only if an unexpected issue occurs during transformation (none in current implementation).
 // This function uses a worker pool to parallelize transformation for better performance on large batches.
-func (t *MongoToDynamoTransformer) Transform(input []map[string]interface{}) ([]map[string]interface{}, error) {
+func (t *DocTransformer) Transform(input []map[string]interface{}) ([]map[string]interface{}, error) {
 	output := make([]map[string]interface{}, len(input))
 	if len(input) == 0 {
 		return output, nil

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-func TestMongoToDynamoTransformer_Transform(t *testing.T) {
-	trans := NewMongoToDynamoTransformer()
+func TestDocTransformer_Transform(t *testing.T) {
+	docTransformer := NewDocTransformer()
 	input := []map[string]interface{}{
 		{"_id": "abc123", "__v": 1, "_class": "com.example.MyEntity", "name": "test"},
 		{"_id": "def456", "__v": 2, "name": "test2", "other": 42},
@@ -29,7 +29,7 @@ func TestMongoToDynamoTransformer_Transform(t *testing.T) {
 			k := r.Intn(j + 1)
 			shuffled[j], shuffled[k] = shuffled[k], shuffled[j]
 		}
-		output, err := trans.Transform(shuffled)
+		output, err := docTransformer.Transform(shuffled)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -73,10 +73,10 @@ func TestMongoToDynamoTransformer_Transform(t *testing.T) {
 	}
 }
 
-func TestMongoToDynamoTransformer_Transform_EmptyInput(t *testing.T) {
-	trans := NewMongoToDynamoTransformer()
+func TestDocTransformer_Transform_EmptyInput(t *testing.T) {
+	docTransformer := NewDocTransformer()
 	input := []map[string]interface{}{}
-	output, err := trans.Transform(input)
+	output, err := docTransformer.Transform(input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
This pull request refactors the codebase to improve clarity and consistency by renaming key components and updating their associated implementations and tests. The changes primarily involve renaming `DataExtractor` and `DataLoader` to `MongoExtractor` and `DynamoLoader`, respectively, and aligning their interfaces and test cases with the new naming conventions.

### Refactoring of Extractor Components:
* [`internal/common/interfaces.go`](diffhunk://#diff-fb0402d90a50c88994fc12453ed2c3f545627f1ee4d21ea3a20fc27d8bd36dffL7-R14): Renamed `DataExtractor` to `Extractor` and updated its interface definition. Similarly, renamed `DataLoader` to `Loader`.
* [`internal/extractor/extractor.go`](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L27-R44): Replaced `Extractor` with `MongoExtractor`, including updates to the constructor (`newMongoExtractor`) and method implementations. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L27-R44) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L86-R93)

### Refactoring of Loader Components:
* [`internal/loader/loader.go`](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL25-R49): Renamed `Loader` to `DynamoLoader` and updated its constructor (`newDynamoLoader`) and method implementations. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL25-R49) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL88-R88) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL130-R136)

### Updates to Command Logic:
* [`cmd/apply/apply.go`](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL52-R72): Updated references to use `MongoExtractor` and `DynamoLoader` in the `runApply` function.
* [`cmd/plan/plan.go`](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L43-R54): Updated references to use `MongoExtractor` in the `runPlan` function.

### Test Case Updates:
* [`internal/extractor/extractor_test.go`](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L85-R85): Updated test cases to reflect the renaming of `Extractor` to `MongoExtractor`. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L85-R85) [[2]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L94-R97) [[3]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L121-R124) [[4]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L151-R155) [[5]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L173-R174) [[6]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L195-R197) [[7]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L222-R225) [[8]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L248-R249)
* [`internal/loader/loader_test.go`](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L32-R54): Updated test cases to reflect the renaming of `Loader` to `DynamoLoader`. [[1]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L32-R54) [[2]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L68-R76) [[3]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L95-R115) [[4]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L129-R137) [[5]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L158-R166) [[6]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L192-R200)