### PR TITLE
fix(cmd): Correct configuration loading priority order

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -62,6 +62,11 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		cfg.AutoApprove, _ = cmd.Flags().GetBool("auto-approve")
 	}
 
+	// Validate configuration after all values are set.
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	// Confirm before proceeding.
 	if !cfg.AutoApprove {
 		if !common.Confirm("Are you sure you want to proceed with the migration? (y/N) ") {

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -52,6 +52,11 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	// Set dry run mode.
 	cfg.SetDryRun(true)
 
+	// Validate configuration after all values are set.
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	// Create mongoExtractor using configuration.
 	mongoExtractor, err := extractor.NewMongoExtractor(cmd.Context(), cfg)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,15 +96,11 @@ func (c *Config) Load() error {
 		c.DryRun = v.GetBool("dry_run")
 	}
 
-	if err := c.validate(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
-// validate checks if all required fields are set.
-func (c *Config) validate() error {
+// Validate checks if all required fields are set.
+func (c *Config) Validate() error {
 	if c.MongoDB == "" {
 		return &common.ConfigFieldError{Field: "mongo_db", Reason: "required"}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,7 +208,7 @@ func TestConfig_validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.validate()
+			err := tt.config.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Config.validate() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This pull request refactors the configuration handling in the `apply` and `plan` commands, improves validation logic, and updates relevant tests. The changes enhance clarity and ensure that configuration overrides are applied consistently.

### Configuration Handling Updates:
* [`cmd/apply/apply.go`](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL28-R67): Refactored configuration loading to first load defaults, environment variables, and config file values, then override them with explicitly set flag values. Added validation after all values are set.
* [`cmd/plan/plan.go`](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L27-R57): Similar refactoring as `apply.go`, with added dry-run mode setting for the `plan` command.

### Validation Logic:
* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL99-R103): Renamed `validate` method to `Validate` for consistency and refactored its invocation to occur explicitly after configuration loading.

### Test Updates:
* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L211-R211): Updated tests to use the renamed `Validate` method, ensuring compatibility with the refactored validation logic.