### PR TITLE
refactor(errors): Unify configuration error types

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -27,7 +27,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	// Load configuration from environment variables, config file, and defaults first.
 	if err := cfg.Load(); err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return &common.ConfigError{Op: "load", Reason: "failed to load from environment variables and config file", Err: err}
 	}
 
 	// Then override with flag values if they were explicitly set.
@@ -64,7 +64,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	// Validate configuration after all values are set.
 	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("invalid configuration: %w", err)
+		return &common.ConfigError{Op: "validate", Reason: "invalid configuration", Err: err}
 	}
 
 	// Confirm before proceeding.

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -26,7 +26,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 
 	// Load configuration from environment variables, config file, and defaults first.
 	if err := cfg.Load(); err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return &common.ConfigError{Op: "load", Reason: "failed to load from environment variables and config file", Err: err}
 	}
 
 	// Then override with flag values if they were explicitly set.
@@ -54,7 +54,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 
 	// Validate configuration after all values are set.
 	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("invalid configuration: %w", err)
+		return &common.ConfigError{Op: "validate", Reason: "invalid configuration", Err: err}
 	}
 
 	// Create mongoExtractor using configuration.

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -2,14 +2,22 @@ package common
 
 import "fmt"
 
-// ConfigFieldError is returned when configuration is invalid or missing required fields.
-type ConfigFieldError struct {
-	Field  string
+// ConfigError is returned for general configuration loading and validation errors.
+type ConfigError struct {
+	Op     string
 	Reason string
+	Err    error
 }
 
-func (e *ConfigFieldError) Error() string {
-	return fmt.Sprintf("invalid configuration for field '%s': %s", e.Field, e.Reason)
+func (e *ConfigError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("configuration error during '%s': %s: %v", e.Op, e.Reason, e.Err)
+	}
+	return fmt.Sprintf("configuration error during '%s': %s", e.Op, e.Reason)
+}
+
+func (e *ConfigError) Unwrap() error {
+	return e.Err
 }
 
 // DataValidationError is returned for data validation errors not related to config.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,13 +102,13 @@ func (c *Config) Load() error {
 // Validate checks if all required fields are set.
 func (c *Config) Validate() error {
 	if c.MongoDB == "" {
-		return &common.ConfigFieldError{Field: "mongo_db", Reason: "required"}
+		return &common.ConfigError{Op: "validate", Reason: "mongo_db field is required"}
 	}
 	if c.MongoCollection == "" {
-		return &common.ConfigFieldError{Field: "mongo_collection", Reason: "required"}
+		return &common.ConfigError{Op: "validate", Reason: "mongo_collection field is required"}
 	}
 	if c.DynamoTable == "" && !c.DryRun {
-		return &common.ConfigFieldError{Field: "dynamo_table", Reason: "required unless dry run"}
+		return &common.ConfigError{Op: "validate", Reason: "dynamo_table field is required unless dry run"}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -216,9 +216,9 @@ func TestConfig_validate(t *testing.T) {
 
 			if tt.wantErr && err != nil {
 				// Check error type.
-				var configErr *common.ConfigFieldError
+				var configErr *common.ConfigError
 				if !errors.As(err, &configErr) {
-					t.Errorf("Expected ConfigFieldError, got %T", err)
+					t.Errorf("Expected ConfigError, got %T", err)
 				}
 
 				// Check error message content.
@@ -229,9 +229,9 @@ func TestConfig_validate(t *testing.T) {
 					}
 				}
 
-				// Check ConfigFieldError fields.
-				if configErr.Field != tt.expectedErr {
-					t.Errorf("ConfigFieldError.Field should be '%s', got '%s'", tt.expectedErr, configErr.Field)
+				// Check ConfigError fields.
+				if !strings.Contains(configErr.Reason, tt.expectedErr) {
+					t.Errorf("ConfigError.Reason should contain '%s', got '%s'", tt.expectedErr, configErr.Reason)
 				}
 			}
 		})


### PR DESCRIPTION
This pull request refactors error handling for configuration-related operations by replacing the `ConfigFieldError` type with a more general `ConfigError` type. This change simplifies error representation and improves clarity in error messages across the codebase.

### Refactoring of Configuration Error Handling:

* **Introduction of `ConfigError` type**: Replaced the `ConfigFieldError` type with a new `ConfigError` type to provide a more general structure for configuration errors, including operation (`Op`), reason (`Reason`), and optional wrapped error (`Err`). Updated the `Error` method to format error messages accordingly and added an `Unwrap` method for error chaining. (`internal/common/errors.go`, [internal/common/errors.goL5-R20](diffhunk://#diff-79d08581e4c4432fa68de3c62292fe52a63e556b6f99baae2a845565e0daf19bL5-R20))

* **Updates to `Validate` method in `Config`**: Refactored error handling in the `Validate` method to use `ConfigError` for better consistency and clarity in error messages when required fields are missing. (`internal/config/config.go`, [internal/config/config.goL105-R111](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL105-R111))

### Changes in Command Error Handling:

* **Refactor in `runApply` function**: Updated error handling in the `runApply` function to use `ConfigError` for both loading and validation errors, improving error specificity. (`cmd/apply/apply.go`, [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL30-R30) [[2]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL67-R67)

* **Refactor in `runPlan` function**: Applied the same `ConfigError` refactoring to the `runPlan` function for consistency in error handling across commands. (`cmd/plan/plan.go`, [[1]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L29-R29) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L57-R57)

### Test Adjustments:

* **Updates to `TestConfig_validate`**: Modified unit tests to check for `ConfigError` instead of `ConfigFieldError`, ensuring compatibility with the new error type and validating its fields (`Reason`). (`internal/config/config_test.go`, [[1]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L219-R221) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L232-R234)