### PR TITLE
fix(transformer): Convert MongoDB ObjectId to string for DynamoDB compatibility

### DIFF
--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -1,10 +1,13 @@
 package transformer
 
 import (
+	"encoding/json"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestDocTransformer_Transform(t *testing.T) {
@@ -82,5 +85,129 @@ func TestDocTransformer_Transform_EmptyInput(t *testing.T) {
 	}
 	if len(output) != 0 {
 		t.Errorf("expected output length 0, got %d", len(output))
+	}
+}
+
+func TestConvertID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "ObjectID conversion",
+			input:    primitive.NewObjectID(),
+			expected: "", // Will be set dynamically.
+		},
+		{
+			name:     "string conversion",
+			input:    "test123",
+			expected: "test123",
+		},
+		{
+			name:     "integer conversion",
+			input:    42,
+			expected: "42",
+		},
+		{
+			name:     "float conversion",
+			input:    3.14,
+			expected: "3.14",
+		},
+		{
+			name:     "boolean conversion",
+			input:    true,
+			expected: "true",
+		},
+		{
+			name:     "nil conversion",
+			input:    nil,
+			expected: "null",
+		},
+		{
+			name: "primitive.M conversion",
+			input: primitive.M{
+				"user": "some user",
+				"ts":   "2023-01-01T00:00:00Z",
+			},
+			expected: `{"ts":"2023-01-01T00:00:00Z","user":"some user"}`,
+		},
+		{
+			name: "nested primitive.M conversion",
+			input: primitive.M{
+				"user": primitive.M{
+					"id":   "123",
+					"name": "John Doe",
+				},
+				"timestamp": "2023-01-01T00:00:00Z",
+			},
+			expected: `{"timestamp":"2023-01-01T00:00:00Z","user":{"id":"123","name":"John Doe"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertID(tt.input)
+
+			// Special handling for ObjectID test.
+			switch tt.name {
+			case "ObjectID conversion":
+				// Verify it's a valid hex string.
+				if len(result) != 24 {
+					t.Errorf("ObjectID conversion: expected 24-character hex string, got %s (length: %d)", result, len(result))
+				}
+				// Verify it's the same as the original ObjectID's hex representation.
+				objID := tt.input.(primitive.ObjectID)
+				expectedHex := objID.Hex()
+				if result != expectedHex {
+					t.Errorf("ObjectID conversion: expected %s, got %s", expectedHex, result)
+				}
+			case "primitive.M conversion", "nested primitive.M conversion":
+				// For JSON objects, we need to parse and compare the structure.
+				var resultMap, expectedMap map[string]interface{}
+
+				if err := json.Unmarshal([]byte(result), &resultMap); err != nil {
+					t.Errorf("Failed to unmarshal result JSON: %v", err)
+					return
+				}
+				if err := json.Unmarshal([]byte(tt.expected), &expectedMap); err != nil {
+					t.Errorf("Failed to unmarshal expected JSON: %v", err)
+					return
+				}
+
+				if !reflect.DeepEqual(resultMap, expectedMap) {
+					t.Errorf("convertID() = %v, want %v", result, tt.expected)
+				}
+			default:
+				if result != tt.expected {
+					t.Errorf("convertID() = %v, want %v", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertID_ObjectIDVariations(t *testing.T) {
+	// Test with a known ObjectID.
+	knownHex := "1234567890abcdef12345678"
+	objID, err := primitive.ObjectIDFromHex(knownHex)
+	if err != nil {
+		t.Fatalf("Failed to create ObjectID from hex: %v", err)
+	}
+
+	result := convertID(objID)
+	if result != knownHex {
+		t.Errorf("convertID() with known ObjectID = %s, want %s", result, knownHex)
+	}
+
+	// Test with multiple random ObjectIDs.
+	for i := 0; i < 10; i++ {
+		randomObjID := primitive.NewObjectID()
+		result := convertID(randomObjID)
+		expected := randomObjID.Hex()
+
+		if result != expected {
+			t.Errorf("convertID() with random ObjectID = %s, want %s", result, expected)
+		}
 	}
 }


### PR DESCRIPTION
This pull request enhances the `DocTransformer` functionality by introducing a new `convertID` helper function for converting MongoDB `_id` fields to DynamoDB-compatible string formats. It also adds comprehensive tests for the new functionality to ensure robustness and correctness.

### Enhancements to MongoDB `_id` Conversion:

* **New `convertID` Function**: Added a helper function to handle conversion of MongoDB `_id` fields to DynamoDB-compatible strings. It supports `primitive.ObjectID`, strings, and complex objects like `bson.M` by converting them to JSON strings or falling back to string representations. (`internal/transformer/transformer.go`, [internal/transformer/transformer.goR33-R58](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R33-R58))
* **Integration into `DocTransformer.Transform`**: Updated the `_id` field handling in the `Transform` method to use the `convertID` function, ensuring compatibility with DynamoDB. (`internal/transformer/transformer.go`, [internal/transformer/transformer.goL78-R108](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L78-R108))

### Testing Improvements:

* **Unit Tests for `convertID`**: Added a comprehensive suite of tests for the `convertID` function, covering various input types such as `ObjectID`, strings, integers, floats, booleans, `nil`, and complex nested objects (`primitive.M`). (`internal/transformer/transformer_test.go`, [internal/transformer/transformer_test.goR90-R213](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005R90-R213))
* **ObjectID-Specific Tests**: Verified correct conversion of `ObjectID` values, including edge cases with known and random `ObjectID` instances. (`internal/transformer/transformer_test.go`, [internal/transformer/transformer_test.goR90-R213](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005R90-R213)) 

### Dependency Updates:

* **MongoDB Driver Import**: Added the `go.mongodb.org/mongo-driver/bson/primitive` package to support `ObjectID` handling. (`internal/transformer/transformer.go`, [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R4-R10); `internal/transformer/transformer_test.go`, [[2]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005R4-R10)