### PR TITLE
style: Organize imports according to Go conventions

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"mongo2dynamo/internal/common"
 	"mongo2dynamo/internal/config"
 	"mongo2dynamo/internal/extractor"
 	"mongo2dynamo/internal/flags"
 	"mongo2dynamo/internal/loader"
 	"mongo2dynamo/internal/transformer"
-
-	"github.com/spf13/cobra"
 )
 
 // ApplyCmd represents the apply command.

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -2,13 +2,14 @@ package plan
 
 import (
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"mongo2dynamo/internal/common"
 	"mongo2dynamo/internal/config"
 	"mongo2dynamo/internal/extractor"
 	"mongo2dynamo/internal/flags"
 	"mongo2dynamo/internal/transformer"
-
-	"github.com/spf13/cobra"
 )
 
 // PlanCmd represents the plan command.

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -3,9 +3,9 @@ package version
 import (
 	"fmt"
 
-	"mongo2dynamo/internal/version"
-
 	"github.com/spf13/cobra"
+
+	"mongo2dynamo/internal/version"
 )
 
 // VersionCmd represents the version command.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,11 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
-	"mongo2dynamo/internal/common"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/viper"
+
+	"mongo2dynamo/internal/common"
 )
 
 // Config holds all configuration for the application.

--- a/internal/dynamo/dynamo.go
+++ b/internal/dynamo/dynamo.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"time"
 
-	"mongo2dynamo/internal/common"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+
+	"mongo2dynamo/internal/common"
 )
 
 // Connect establishes a connection to DynamoDB.

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -2,12 +2,13 @@ package extractor
 
 import (
 	"context"
-	"mongo2dynamo/internal/common"
-	"mongo2dynamo/internal/mongo"
 
 	"go.mongodb.org/mongo-driver/bson"
 	goMongo "go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/mongo"
 )
 
 // Collection defines the interface for MongoDB collection operations needed by Extractor.

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 	"testing"
 
-	"mongo2dynamo/internal/common"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"mongo2dynamo/internal/common"
 )
 
 // MockCollection is a mock implementation of Collection interface.

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -3,10 +3,10 @@ package flags_test
 import (
 	"testing"
 
-	"mongo2dynamo/internal/flags"
-
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"mongo2dynamo/internal/flags"
 )
 
 func TestAddMongoFlags(t *testing.T) {

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"time"
 
-	"mongo2dynamo/internal/common"
-	"mongo2dynamo/internal/dynamo"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/dynamo"
 )
 
 const batchSize = 25

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"testing"
 
-	"mongo2dynamo/internal/common"
-
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"mongo2dynamo/internal/common"
 )
 
 // MockDynamoDBClient is a mock implementation of DBClient for testing.

--- a/internal/mongo/mongo.go
+++ b/internal/mongo/mongo.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"strings"
 
-	"mongo2dynamo/internal/common"
-
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"mongo2dynamo/internal/common"
 )
 
 // mongoAuthErrorPatterns contains common authentication failure patterns for MongoDB errors.


### PR DESCRIPTION
This pull request refactors import statements across multiple files in the `mongo2dynamo` project to improve consistency and readability. The changes primarily involve reordering imports to ensure third-party libraries are grouped separately from internal modules.

### Refactoring of import statements:

* **Command-related files**:
  - Reordered imports in `cmd/apply/apply.go`, `cmd/plan/plan.go`, and `cmd/version/version.go` to place third-party libraries (`github.com/spf13/cobra`) after internal modules. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR7-L14) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R5-L11) [[3]](diffhunk://#diff-638f1a6c08b445854a22e46b58a13eebdf98812c604b98a956550bf4ddc6bec1L6-R8)

* **Internal module files**:
  - Adjusted import order in `internal/config/config.go`, `internal/dynamo/dynamo.go`, `internal/extractor/extractor.go`, and `internal/mongo/mongo.go` to ensure `mongo2dynamo/internal/common` appears after third-party libraries. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL6-R11) [[2]](diffhunk://#diff-83aabefb38a4bad355bf831c068bc9315140f4369ad8deff2e804d56c50e5756L7-R11) [[3]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L5-R11) [[4]](diffhunk://#diff-f04a773a82b8b9b655a189e79a6501d3cd6ec7910e99e36d57e0573594c26759L8-R11)

* **Test files**:
  - Updated import order in `internal/extractor/extractor_test.go`, `internal/flags/flags_test.go`, `internal/loader/loader.go`, and `internal/loader/loader_test.go` to align with the new grouping convention. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L10-R14) [[2]](diffhunk://#diff-623285afd36b10830f3d03debfd2d69c23bccc6223330a60479d2513128db5a7L6-R9) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL9-R15) [[4]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L9-R14)