### PR TITLE
feat: Add periods to user-facing messages for consistency

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -113,7 +113,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return &common.ApplyError{Reason: "unexpected error during apply callback", Err: err}
 	}
-	fmt.Printf("Successfully migrated %d documents\n", migrated)
+	fmt.Printf("Successfully migrated %d documents.\n", migrated)
 	return nil
 }
 

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -80,7 +80,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return &common.PlanError{Reason: "unexpected error during plan callback", Err: err}
 	}
-	fmt.Printf("Found %d documents to migrate\n", total)
+	fmt.Printf("Found %d documents to migrate.\n", total)
 	return nil
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -184,7 +184,7 @@ func TestApplyCommand_WithExistingTable(t *testing.T) {
 
 	// Verify apply command output messages.
 	outputStr := string(output)
-	require.Contains(t, outputStr, "Successfully migrated 1 documents", "Apply output should show successful migration")
+	require.Contains(t, outputStr, "Successfully migrated 1 documents.", "Apply output should show successful migration")
 	require.Contains(t, outputStr, "Table 'test_table' already exists.", "Should detect existing table")
 
 	// Verify data in DynamoDB.
@@ -255,7 +255,7 @@ func TestApplyCommand_WithAutoCreateTable(t *testing.T) {
 
 	// Verify apply command output messages.
 	outputStr := string(output)
-	require.Contains(t, outputStr, "Successfully migrated 1 documents", "Apply output should show successful migration")
+	require.Contains(t, outputStr, "Successfully migrated 1 documents.", "Apply output should show successful migration")
 	require.Contains(t, outputStr, "Auto-creating table 'test_table_auto'...", "Should show auto-creation message")
 	require.Contains(t, outputStr, "Creating DynamoDB table 'test_table_auto'...", "Should show table creation message")
 	require.Contains(t, outputStr, "Waiting for table 'test_table_auto' to become active...", "Should show waiting message")
@@ -318,7 +318,7 @@ func TestPlanCommand(t *testing.T) {
 
 	// Verify plan command output messages.
 	outputStr := string(output)
-	require.Contains(t, outputStr, "Found 1 documents to migrate", "Plan output should show found documents")
+	require.Contains(t, outputStr, "Found 1 documents to migrate.", "Plan output should show found documents")
 	require.NotContains(t, outputStr, "Successfully migrated", "Plan output should not show success message in dry run mode")
 }
 


### PR DESCRIPTION
This pull request standardizes the output messages in the `apply` and `plan` commands by ensuring all messages end with a period for consistency. Corresponding updates were made to integration tests to reflect these changes.

### Standardization of output messages:
* [`cmd/apply/apply.go`](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL116-R116): Updated the success message in the `apply` command to end with a period.
* [`cmd/plan/plan.go`](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L83-R83): Updated the message in the `plan` command to end with a period.

### Updates to integration tests:
* [`test/integration/integration_test.go`](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL187-R187): Modified `TestApplyCommand_WithExistingTable` to check for the updated success message ending with a period.
* [`test/integration/integration_test.go`](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL258-R258): Modified `TestApplyCommand_WithAutoCreateTable` to check for the updated success message ending with a period.
* [`test/integration/integration_test.go`](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL321-R321): Updated `TestPlanCommand` to check for the updated message ending with a period.