### PR TITLE
fix: Prevent duplicate error message output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,14 +13,16 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "mongo2dynamo",
-	Short: "CLI tool to migrate data from MongoDB to DynamoDB",
-	Long:  `A command-line tool to copy all documents from MongoDB into AWS DynamoDB.`,
+	Use:           "mongo2dynamo",
+	Short:         "CLI tool to migrate data from MongoDB to DynamoDB",
+	Long:          `A command-line tool to copy all documents from MongoDB into AWS DynamoDB.`,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		rootCmd.PrintErrf("Error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This pull request includes improvements to the error handling and user experience in the `mongo2dynamo` CLI tool.

Error handling updates:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR19-R25): Added `SilenceErrors` and `SilenceUsage` to the `rootCmd` configuration to suppress redundant error messages and usage output during execution.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR19-R25): Updated the error message formatting in the `Execute` function to provide clearer and more user-friendly output.