### PR TITLE
refactor: Standardize error output using Cobra's PrintErrf

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -29,7 +28,7 @@ func Execute() {
 
 func bindPersistentFlags() {
 	if err := viper.BindPFlag("auto-approve", rootCmd.PersistentFlags().Lookup("auto-approve")); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to bind auto-approve flag: %v\n", err)
+		rootCmd.PrintErrf("Failed to bind auto-approve flag: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This pull request focuses on improving error handling and code consistency in the `cmd/root.go` file. The most notable change replaces the use of `fmt.Fprintf` with `rootCmd.PrintErrf` for error messages, aligning with the `cobra` library's built-in methods for better integration.

Error handling improvements:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL32-R31): Replaced `fmt.Fprintf` with `rootCmd.PrintErrf` in the `bindPersistentFlags` function to standardize error handling using the `cobra` library's methods.

Code cleanup:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL4): Removed the unused `fmt` import, reducing unnecessary dependencies.