### PR TITLE
feat: Add smart table naming using collection name as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Batch-based, memory-efficient processing**: Extracts and loads data in configurable batches (default: 1000 documents per chunk), allowing efficient handling of large datasets without excessive memory usage.
 - **Auto-approve and interactive confirmation**: Supports both automated ETL runs (for CI/CD or scripting) and interactive confirmation prompts to prevent accidental data transfers.
 - **Automatic DynamoDB table creation**: Automatically creates DynamoDB tables if they don't exist, with configurable behavior through the auto-approve flag.
+- **Smart table naming**: If `--dynamo-table` is not specified, automatically uses the MongoDB collection name as the DynamoDB table name.
 - **Flexible configuration**: Easily configure all options via command-line flags, environment variables, or a YAML config file—whichever fits your workflow best.
 - **Error handling and retry logic**: Automatically retries failed extract/load operations with exponential backoff, and provides clear error messages to help you quickly resolve issues.
 - **Dry-run support**: Use the `plan` command to preview ETL operations before performing any actual data transfer.
@@ -61,14 +62,23 @@ mongo2dynamo plan \
 ### 2. Run Actual Migration
 
 ```bash
-# With auto-approve (automatically creates table if it doesn't exist)
+# Using collection name as table name (recommended for simple migrations)
 mongo2dynamo apply \
   --mongo-host localhost \
   --mongo-port 27017 \
   --mongo-db your_database \
   --mongo-collection your_collection \
   --dynamo-endpoint your_endpoint \
-  --dynamo-table your_table \
+  --auto-approve
+
+# With custom table name
+mongo2dynamo apply \
+  --mongo-host localhost \
+  --mongo-port 27017 \
+  --mongo-db your_database \
+  --mongo-collection your_collection \
+  --dynamo-endpoint your_endpoint \
+  --dynamo-table your_custom_table \
   --auto-approve
 
 # Without auto-approve (prompts for confirmation before creating table)
@@ -92,7 +102,7 @@ export MONGO2DYNAMO_MONGO_USER=your_username
 export MONGO2DYNAMO_MONGO_PASSWORD=your_password
 export MONGO2DYNAMO_MONGO_DB=your_database
 export MONGO2DYNAMO_MONGO_COLLECTION=your_collection
-export MONGO2DYNAMO_DYNAMO_TABLE=your_table
+export MONGO2DYNAMO_DYNAMO_TABLE=your_table  # Optional: defaults to collection name
 export MONGO2DYNAMO_DYNAMO_ENDPOINT=http://localhost:8000
 export MONGO2DYNAMO_AWS_REGION=us-east-1
 ```
@@ -108,7 +118,7 @@ mongo_user: your_username
 mongo_password: your_password
 mongo_db: your_database
 mongo_collection: your_collection
-dynamo_table: your_table
+dynamo_table: your_table  # Optional: defaults to collection name
 dynamo_endpoint: http://localhost:8000
 aws_region: us-east-1
 ```
@@ -134,6 +144,7 @@ The `apply` command executes the full ETL pipeline:
 - **Error Handling**: Implements retry logic with exponential backoff for failed operations.
 
 **Table Creation Behavior**: When the target DynamoDB table doesn't exist, mongo2dynamo can automatically create it:
+- **Table Naming**: If `--dynamo-table` is not specified, the MongoDB collection name is automatically used as the DynamoDB table name.
 - **With `--auto-approve`**: Tables are created automatically with a simple schema (using `id` as the primary key).
 - **Without `--auto-approve`**: The tool prompts for user confirmation before creating the table.
 - **Existing tables**: If the table already exists, the tool uses it as-is without modification.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,9 +108,13 @@ func (c *Config) Validate() error {
 	if c.MongoCollection == "" {
 		return &common.ConfigError{Op: "validate", Reason: "mongo_collection field is required"}
 	}
-	if c.DynamoTable == "" && !c.DryRun {
-		return &common.ConfigError{Op: "validate", Reason: "dynamo_table field is required unless dry run"}
+
+	// If DynamoTable is not set, use MongoCollection name as the table name.
+	if c.DynamoTable == "" {
+		c.DynamoTable = c.MongoCollection
+		fmt.Printf("Using collection name '%s' as DynamoDB table name.\n", c.DynamoTable)
 	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -195,14 +195,13 @@ func TestConfig_validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "missing dynamo_table and not dry run",
+			name: "missing dynamo_table should be set to collection name",
 			config: &Config{
 				MongoDB:         "testdb",
 				MongoCollection: "testcollection",
 				DryRun:          false,
 			},
-			wantErr:     true,
-			expectedErr: "dynamo_table",
+			wantErr: false,
 		},
 	}
 
@@ -233,6 +232,12 @@ func TestConfig_validate(t *testing.T) {
 				if !strings.Contains(configErr.Reason, tt.expectedErr) {
 					t.Errorf("ConfigError.Reason should contain '%s', got '%s'", tt.expectedErr, configErr.Reason)
 				}
+			}
+
+			// Check if DynamoTable is automatically set to MongoCollection when empty.
+			if tt.config.MongoCollection != "" && tt.config.DynamoTable == "" {
+				// This should not happen after Validate() is called.
+				t.Errorf("DynamoTable should be set to MongoCollection '%s' when empty, but it's still empty", tt.config.MongoCollection)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request introduces a feature that simplifies DynamoDB table naming by defaulting to the MongoDB collection name when the `--dynamo-table` flag is not specified. Updates have been made to both the documentation and the codebase to reflect this change, ensuring consistency and clarity for users. Additionally, tests have been updated to validate this new behavior.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26): Added details about the new default behavior for table naming, specifying that the MongoDB collection name is automatically used as the DynamoDB table name if `--dynamo-table` is not provided. Updated examples and configuration sections to reflect this behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R81) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R105) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R121) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147)

### Code Changes:
* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL111-R117): Modified the `Validate` method to set `DynamoTable` to the MongoDB collection name if it is not explicitly provided, with a message indicating the default behavior.

### Test Updates:
* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L198-R204): Updated test cases to ensure `DynamoTable` is automatically set to the MongoDB collection name when left empty, and added validation logic to check this behavior. [[1]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L198-R204) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R236-R241)