### PR TITLE
refactor: Use primitive.M instead of bson.M

### DIFF
--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -3,7 +3,7 @@ package extractor
 import (
 	"context"
 
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	goMongo "go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -77,7 +77,7 @@ func NewMongoExtractor(ctx context.Context, cfg common.ConfigProvider) (common.E
 // Extract retrieves documents from the MongoDB collection in fixed-size chunks and processes them using the provided callback.
 func (e *MongoExtractor) Extract(ctx context.Context, handleChunk common.ChunkHandler) error {
 	findOptions := options.Find().SetBatchSize(int32(e.batchSize))
-	cursor, err := e.collection.Find(ctx, bson.M{}, findOptions)
+	cursor, err := e.collection.Find(ctx, primitive.M{}, findOptions)
 	if err != nil {
 		return &common.DatabaseOperationError{Database: "MongoDB", Op: "find", Reason: err.Error(), Err: err}
 	}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -76,7 +76,7 @@ func setupMongoDB(t *testing.T, mongoHost, mongoPort string) *mongo.Client {
 
 	// Insert test data.
 	collection := mongoClient.Database("testdb").Collection("testcol")
-	_, err = collection.InsertOne(ctx, bson.M{
+	_, err = collection.InsertOne(ctx, primitive.M{
 		"_id":    "mongoid-001",
 		"__v":    7,
 		"_class": "com.example.MyEntity",


### PR DESCRIPTION
This pull request updates the MongoDB driver usage across the codebase to replace `bson.M` with `primitive.M` for better compatibility and adherence to the latest standards. The changes ensure consistent usage of the `primitive` package and improve type safety.

### Updates to MongoDB driver usage:

* **Extractor logic in `internal/extractor/extractor.go`:**
  - Replaced `bson.M` with `primitive.M` in the `Extract` method to align with the updated MongoDB driver conventions.
  - Updated the import statement to include `bson/primitive` instead of `bson`.

* **Integration tests in `test/integration/integration_test.go`:**
  - Changed `bson.M` to `primitive.M` in the `setupMongoDB` function for inserting test data into MongoDB.
  - Adjusted the import statement to use `bson/primitive` instead of `bson`.