### PR TITLE
feat: Improve number formatting for large document counts

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -113,7 +113,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return &common.ApplyError{Reason: "unexpected error during apply callback", Err: err}
 	}
-	fmt.Printf("Successfully migrated %d documents.\n", migrated)
+	fmt.Printf("Successfully migrated %s documents.\n", common.FormatNumber(migrated))
 	return nil
 }
 

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -80,7 +80,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return &common.PlanError{Reason: "unexpected error during plan callback", Err: err}
 	}
-	fmt.Printf("Found %d documents to migrate.\n", total)
+	fmt.Printf("Found %s documents to migrate.\n", common.FormatNumber(total))
 	return nil
 }
 


### PR DESCRIPTION
This pull request updates the formatting of numerical outputs in the `apply` and `plan` commands to improve readability by using the `common.FormatNumber` function.

Changes to numerical formatting:

* [`cmd/apply/apply.go`](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL116-R116): Replaced the raw integer output for the number of migrated documents with a formatted string using `common.FormatNumber`.
* [`cmd/plan/plan.go`](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L83-R83): Replaced the raw integer output for the total number of documents to migrate with a formatted string using `common.FormatNumber`.