### PR TITLE
feat(config): Add --max-retries option for DynamoDB batch write retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **Automatic DynamoDB table creation**: Automatically creates DynamoDB tables if they don't exist, with configurable behavior through the auto-approve flag.
 - **Smart table naming with confirmation**: If `--dynamo-table` is not specified, prompts for user confirmation before using the MongoDB collection name as the DynamoDB table name (only in `apply` command).
 - **Flexible configuration**: Easily configure all options via command-line flags, environment variables, or a YAML config file—whichever fits your workflow best.
-- **Error handling and retry logic**: Automatically retries failed extract/load operations with exponential backoff and jitter to prevent thundering herd problems, and provides clear error messages to help you quickly resolve issues.
+- **Error handling and retry logic**: Automatically retries failed extract/load operations with exponential backoff and jitter to prevent thundering herd problems, and provides clear error messages to help you quickly resolve issues. The maximum number of retries can be configured with the `--max-retries` flag (default: 5).
 - **Dry-run support**: Use the `plan` command to preview ETL operations before performing any actual data transfer.
 
 ## Why mongo2dynamo?
@@ -78,7 +78,8 @@ mongo2dynamo apply \
   --mongo-collection your_collection \
   --dynamo-endpoint your_endpoint \
   --dynamo-table your_custom_table \
-  --auto-approve
+  --auto-approve \
+  --max-retries 10
 
 # With auto-approve (skips all confirmation prompts)
 mongo2dynamo apply \
@@ -104,6 +105,7 @@ export MONGO2DYNAMO_MONGO_COLLECTION=your_collection
 export MONGO2DYNAMO_DYNAMO_TABLE=your_table
 export MONGO2DYNAMO_DYNAMO_ENDPOINT=http://localhost:8000
 export MONGO2DYNAMO_AWS_REGION=us-east-1
+export MONGO2DYNAMO_MAX_RETRIES=10
 ```
 
 ### Config File
@@ -120,6 +122,7 @@ mongo_collection: your_collection
 dynamo_table: your_table
 dynamo_endpoint: http://localhost:8000
 aws_region: us-east-1
+max_retries: 10
 ```
 
 ## How It Works

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -64,6 +64,9 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if cmd.Flags().Changed("auto-approve") {
 		cfg.AutoApprove, _ = cmd.Flags().GetBool("auto-approve")
 	}
+	if cmd.Flags().Changed("max-retries") {
+		cfg.MaxRetries, _ = cmd.Flags().GetInt("max-retries")
+	}
 
 	// Validate configuration after all values are set.
 	if err := cfg.Validate(); err != nil {

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -38,4 +38,6 @@ type ConfigProvider interface {
 	GetDynamoTable() string
 	GetAWSRegion() string
 	GetAutoApprove() bool
+	GetDryRun() bool
+	GetMaxRetries() int
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,8 @@ import (
 	"mongo2dynamo/internal/common"
 )
 
+const defaultMaxRetries = 5
+
 func TestConfig_Load(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -164,6 +166,7 @@ func TestConfig_Validate(t *testing.T) {
 				MongoDB:         "testdb",
 				MongoCollection: "testcollection",
 				DynamoTable:     "testtable",
+				MaxRetries:      defaultMaxRetries,
 			},
 			wantErr: false,
 		},
@@ -172,6 +175,7 @@ func TestConfig_Validate(t *testing.T) {
 			config: &Config{
 				MongoCollection: "testcollection",
 				DynamoTable:     "testtable",
+				MaxRetries:      defaultMaxRetries,
 			},
 			wantErr:     true,
 			expectedErr: "mongo_db",
@@ -181,6 +185,7 @@ func TestConfig_Validate(t *testing.T) {
 			config: &Config{
 				MongoDB:     "testdb",
 				DynamoTable: "testtable",
+				MaxRetries:  defaultMaxRetries,
 			},
 			wantErr:     true,
 			expectedErr: "mongo_collection",
@@ -191,6 +196,7 @@ func TestConfig_Validate(t *testing.T) {
 				MongoDB:         "testdb",
 				MongoCollection: "testcollection",
 				DryRun:          true,
+				MaxRetries:      defaultMaxRetries,
 			},
 			wantErr: false,
 		},
@@ -201,8 +207,31 @@ func TestConfig_Validate(t *testing.T) {
 				MongoCollection: "testcollection",
 				DryRun:          false,
 				AutoApprove:     true,
+				MaxRetries:      defaultMaxRetries,
 			},
 			wantErr: false,
+		},
+		{
+			name: "max_retries is zero",
+			config: &Config{
+				MongoDB:         "testdb",
+				MongoCollection: "testcollection",
+				DynamoTable:     "testtable",
+				MaxRetries:      0,
+			},
+			wantErr:     true,
+			expectedErr: "max_retries",
+		},
+		{
+			name: "max_retries is negative",
+			config: &Config{
+				MongoDB:         "testdb",
+				MongoCollection: "testcollection",
+				DynamoTable:     "testtable",
+				MaxRetries:      -3,
+			},
+			wantErr:     true,
+			expectedErr: "max_retries",
 		},
 	}
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -19,4 +19,5 @@ func AddDynamoFlags(cmd *cobra.Command) {
 	cmd.Flags().String("dynamo-endpoint", "http://localhost:8000", "DynamoDB endpoint.")
 	cmd.Flags().String("dynamo-table", "", "DynamoDB table name.")
 	cmd.Flags().String("aws-region", "us-east-1", "AWS region.")
+	cmd.Flags().Int("max-retries", 5, "Maximum number of retries for DynamoDB batch write.")
 }


### PR DESCRIPTION
This pull request introduces a new configurable parameter, `max-retries`, to enhance the flexibility of error handling and retry logic in the `mongo2dynamo` application. The changes include updates to the configuration system, command-line flags, and the retry mechanism in the DynamoDB loader. Additionally, tests were updated to validate the new functionality.

### Configuration Enhancements:
* Added `max-retries` parameter to the `Config` struct, with a default value of 5, allowing users to specify the maximum number of retries for failed DynamoDB operations. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR33) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR45)
* Updated the `Validate` method in `Config` to ensure `max-retries` is greater than 0.

### Command-Line and Environment Variable Support:
* Added `--max-retries` flag to the `apply` command for specifying retry limits via the command line. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR67-R69) [[2]](diffhunk://#diff-dea4d60e02b3dedd8b784f4254501a4ad4cc9d10ad45e5e8962582574c82920fR22)
* Enabled `max-retries` configuration through environment variables and YAML config files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125)

### Retry Logic Updates:
* Modified the `DynamoLoader` to accept `maxRetries` as a parameter, replacing the hardcoded retry limit. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR44-R53) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL63-R64)
* Updated the retry loop in the `batchWrite` method to use the configurable `maxRetries` value. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL259-R260) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL290-R291)

### Documentation Updates:
* Updated `README.md` to include details about the new `--max-retries` flag and its usage in command examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R82)

### Test Coverage:
* Added test cases to validate `max-retries` behavior, including edge cases like zero and negative values.
* Updated loader tests to use the new `maxRetries` parameter. [[1]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403R58-R66) [[2]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L305-R308)