### PR TITLE
test(flags): Add --max-retries flag validation tests

### DIFF
--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -48,4 +48,8 @@ func TestAddDynamoFlags(t *testing.T) {
 	regionFlag := cmd.Flags().Lookup("aws-region")
 	assert.NotNil(t, regionFlag, "aws-region flag should be registered")
 	assert.Equal(t, "us-east-1", regionFlag.DefValue)
+
+	maxRetriesFlag := cmd.Flags().Lookup("max-retries")
+	assert.NotNil(t, maxRetriesFlag, "max-retries flag should be registered")
+	assert.Equal(t, "5", maxRetriesFlag.DefValue)
 }


### PR DESCRIPTION
This pull request adds a new flag to the `TestAddDynamoFlags` test in `internal/flags/flags_test.go`. The change ensures that the `max-retries` flag is properly registered and has a default value of `5`.