### PR TITLE
feat(extractor): Implement MongoDB filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 - **ETL-based MongoDB → DynamoDB migration**: Extracts data from MongoDB collections, transforms it, and loads it into DynamoDB tables, minimizing the risk of data loss or duplication.
 - **Batch-based, memory-efficient processing**: Extracts and loads data in configurable batches (default: 1000 documents per chunk), allowing efficient handling of large datasets without excessive memory usage.
+- **MongoDB query filtering**: Filter documents during extraction using MongoDB query syntax via the `--mongo-filter` flag, allowing selective migration of data based on specific criteria.
 - **Auto-approve and interactive confirmation**: Supports both automated ETL runs (for CI/CD or scripting) and interactive confirmation prompts to prevent accidental data transfers.
 - **Automatic DynamoDB table creation**: Automatically creates DynamoDB tables if they don't exist, with configurable behavior through the auto-approve flag.
 - **Smart table naming with confirmation**: If `--dynamo-table` is not specified, prompts for user confirmation before using the MongoDB collection name as the DynamoDB table name (only in `apply` command).
@@ -70,7 +71,7 @@ mongo2dynamo apply \
   --mongo-collection your_collection \
   --dynamo-endpoint your_endpoint
 
-# With custom table name
+# With custom table name and MongoDB filter
 mongo2dynamo apply \
   --mongo-host localhost \
   --mongo-port 27017 \
@@ -78,8 +79,7 @@ mongo2dynamo apply \
   --mongo-collection your_collection \
   --dynamo-endpoint your_endpoint \
   --dynamo-table your_custom_table \
-  --auto-approve \
-  --max-retries 10
+  --mongo-filter '{"status": "active", "age": {"$gte": 18}}'
 
 # With auto-approve (skips all confirmation prompts)
 mongo2dynamo apply \
@@ -89,6 +89,7 @@ mongo2dynamo apply \
   --mongo-collection your_collection \
   --dynamo-endpoint your_endpoint \
   --auto-approve
+  --max-retries 10
 ```
 
 ## Configuration
@@ -102,6 +103,7 @@ export MONGO2DYNAMO_MONGO_USER=your_username
 export MONGO2DYNAMO_MONGO_PASSWORD=your_password
 export MONGO2DYNAMO_MONGO_DB=your_database
 export MONGO2DYNAMO_MONGO_COLLECTION=your_collection
+export MONGO2DYNAMO_MONGO_FILTER='{"status": "active"}'
 export MONGO2DYNAMO_DYNAMO_TABLE=your_table
 export MONGO2DYNAMO_DYNAMO_ENDPOINT=http://localhost:8000
 export MONGO2DYNAMO_AWS_REGION=us-east-1
@@ -119,6 +121,7 @@ mongo_user: your_username
 mongo_password: your_password
 mongo_db: your_database
 mongo_collection: your_collection
+mongo_filter: '{"status": "active"}'
 dynamo_table: your_table
 dynamo_endpoint: http://localhost:8000
 aws_region: us-east-1
@@ -139,7 +142,7 @@ The `plan` command performs a dry-run of the ETL process:
 ### 2. Apply Phase
 The `apply` command executes the full ETL pipeline:
 - **Connection Setup**: Establishes connections to both MongoDB and DynamoDB.
-- **Extraction**: Extracts documents from MongoDB in configurable batches (default: 1000 documents per chunk).
+- **Extraction**: Extracts documents from MongoDB in configurable batches (default: 1000 documents per chunk). If a `--mongo-filter` is specified, only documents matching the filter criteria are extracted.
 - **Transformation**: Transforms MongoDB BSON documents to DynamoDB-compatible format.
 - **Table Management**: Automatically checks if the DynamoDB table exists and creates it if needed, with user confirmation based on the auto-approve setting.
 - **Loading**: Loads transformed data into DynamoDB using the BatchWriteItem API.

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -67,6 +67,9 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if cmd.Flags().Changed("max-retries") {
 		cfg.MaxRetries, _ = cmd.Flags().GetInt("max-retries")
 	}
+	if cmd.Flags().Changed("mongo-filter") {
+		cfg.MongoFilter, _ = cmd.Flags().GetString("mongo-filter")
+	}
 
 	// Validate configuration after all values are set.
 	if err := cfg.Validate(); err != nil {

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -51,6 +51,9 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	if cmd.Flags().Changed("mongo-collection") {
 		cfg.MongoCollection, _ = cmd.Flags().GetString("mongo-collection")
 	}
+	if cmd.Flags().Changed("mongo-filter") {
+		cfg.MongoFilter, _ = cmd.Flags().GetString("mongo-filter")
+	}
 
 	// Set dry run mode.
 	cfg.SetDryRun(true)

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -95,6 +95,25 @@ func (e *AuthError) Unwrap() error {
 	return e.Err
 }
 
+// FilterParseError is returned when MongoDB filter parsing fails.
+type FilterParseError struct {
+	Filter string
+	Op     string
+	Reason string
+	Err    error
+}
+
+func (e *FilterParseError) Error() string {
+	if e.Filter != "" {
+		return fmt.Sprintf("MongoDB filter parse error during '%s' for filter '%s': %s", e.Op, e.Filter, e.Reason)
+	}
+	return fmt.Sprintf("MongoDB filter parse error during '%s': %s", e.Op, e.Reason)
+}
+
+func (e *FilterParseError) Unwrap() error {
+	return e.Err
+}
+
 // ExtractError is returned when creating or initializing an extractor fails.
 type ExtractError struct {
 	Reason string

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -34,6 +34,7 @@ type ConfigProvider interface {
 	GetMongoDB() string
 	GetMongoCollection() string
 	GetMongoURI() string
+	GetMongoFilter() string
 	GetDynamoEndpoint() string
 	GetDynamoTable() string
 	GetAWSRegion() string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	MongoPassword   string
 	MongoDB         string
 	MongoCollection string
+	MongoFilter     string
 
 	// DynamoDB configuration.
 	DynamoTable    string
@@ -43,6 +44,7 @@ func (c *Config) Load() error {
 	v.SetDefault("dynamo_endpoint", "http://localhost:8000")
 	v.SetDefault("aws_region", "us-east-1")
 	v.SetDefault("max_retries", 5)
+	v.SetDefault("mongo_filter", "")
 
 	// Read from environment variables.
 	v.SetEnvPrefix("MONGO2DYNAMO")
@@ -83,6 +85,9 @@ func (c *Config) Load() error {
 	}
 	if c.MongoCollection == "" {
 		c.MongoCollection = v.GetString("mongo_collection")
+	}
+	if c.MongoFilter == "" {
+		c.MongoFilter = v.GetString("mongo_filter")
 	}
 	if c.DynamoTable == "" {
 		c.DynamoTable = v.GetString("dynamo_table")
@@ -153,6 +158,10 @@ func (c *Config) GetMongoDB() string {
 
 func (c *Config) GetMongoCollection() string {
 	return c.MongoCollection
+}
+
+func (c *Config) GetMongoFilter() string {
+	return c.MongoFilter
 }
 
 func (c *Config) GetMongoURI() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,7 @@ func TestConfig_Load(t *testing.T) {
 				"MONGO2DYNAMO_MONGO_PORT":       "27018",
 				"MONGO2DYNAMO_MONGO_DB":         "testdb",
 				"MONGO2DYNAMO_MONGO_COLLECTION": "testcollection",
+				"MONGO2DYNAMO_MONGO_FILTER":     `{"status": "active"}`,
 				"MONGO2DYNAMO_DYNAMO_TABLE":     "testtable",
 				"MONGO2DYNAMO_DYNAMO_ENDPOINT":  "http://test:8000",
 				"MONGO2DYNAMO_AWS_REGION":       "us-west-2",
@@ -77,6 +78,9 @@ func TestConfig_Load(t *testing.T) {
 				}
 				if tt.envVars["MONGO2DYNAMO_MONGO_PORT"] != "" && tt.config.MongoPort != tt.envVars["MONGO2DYNAMO_MONGO_PORT"] {
 					t.Errorf("MongoPort should be '%s', got '%s'", tt.envVars["MONGO2DYNAMO_MONGO_PORT"], tt.config.MongoPort)
+				}
+				if tt.envVars["MONGO2DYNAMO_MONGO_FILTER"] != "" && tt.config.MongoFilter != tt.envVars["MONGO2DYNAMO_MONGO_FILTER"] {
+					t.Errorf("MongoFilter should be '%s', got '%s'", tt.envVars["MONGO2DYNAMO_MONGO_FILTER"], tt.config.MongoFilter)
 				}
 				if tt.envVars["MONGO2DYNAMO_DYNAMO_ENDPOINT"] != "" && tt.config.DynamoEndpoint != tt.envVars["MONGO2DYNAMO_DYNAMO_ENDPOINT"] {
 					t.Errorf("DynamoEndpoint should be '%s', got '%s'", tt.envVars["MONGO2DYNAMO_DYNAMO_ENDPOINT"], tt.config.DynamoEndpoint)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -12,6 +12,7 @@ func AddMongoFlags(cmd *cobra.Command) {
 	cmd.Flags().String("mongo-password", "", "MongoDB password.")
 	cmd.Flags().String("mongo-db", "", "MongoDB database name.")
 	cmd.Flags().String("mongo-collection", "", "MongoDB collection name.")
+	cmd.Flags().String("mongo-filter", "", "MongoDB query filter (JSON string)")
 }
 
 // AddDynamoFlags adds DynamoDB-related flags to the command.

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -32,6 +32,10 @@ func TestAddMongoFlags(t *testing.T) {
 
 	collectionFlag := cmd.Flags().Lookup("mongo-collection")
 	assert.NotNil(t, collectionFlag, "mongo-collection flag should be registered")
+
+	filterFlag := cmd.Flags().Lookup("mongo-filter")
+	assert.NotNil(t, filterFlag, "mongo-filter flag should be registered")
+	assert.Equal(t, "", filterFlag.DefValue)
 }
 
 func TestAddDynamoFlags(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new feature to support MongoDB query filtering during the ETL process, allowing users to specify filter criteria for selective data migration. It also includes updates to the configuration, error handling, and documentation to accommodate this feature.

### MongoDB Query Filtering Feature:

* [`internal/extractor/extractor.go`](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L74-R142): Added support for parsing and applying MongoDB query filters using the `--mongo-filter` flag. Filters are parsed from JSON strings and converted to BSON format for MongoDB queries. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L74-R142) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0R34) [[3]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L59-R67)
* [`internal/common/errors.go`](diffhunk://#diff-79d08581e4c4432fa68de3c62292fe52a63e556b6f99baae2a845565e0daf19bR98-R116): Introduced a new `FilterParseError` type to handle errors related to MongoDB filter parsing.
* `cmd/apply/apply.go` and `cmd/plan/plan.go`: Updated the `apply` and `plan` commands to accept the `--mongo-filter` flag and integrate it into the configuration. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR70-R72) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R54-R56)

### Configuration Updates:

* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR24): Added `MongoFilter` to the configuration structure, with support for environment variables and default values. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR24) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR47) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR163-R166)
* [`internal/common/interfaces.go`](diffhunk://#diff-fb0402d90a50c88994fc12453ed2c3f545627f1ee4d21ea3a20fc27d8bd36dffR37): Updated the `ConfigProvider` interface to include a `GetMongoFilter` method.
* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R29): Enhanced tests to validate the `MongoFilter` configuration. [[1]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R29) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R82-R84)

### Documentation Enhancements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24): Updated documentation to describe the new `--mongo-filter` flag, including usage examples and explanations of its functionality. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R82) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R145)

### Testing Improvements:

* [`internal/extractor/extractor_test.go`](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L94-R95): Modified extractor tests to account for the new filter functionality, ensuring compatibility and robustness. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L94-R95) [[2]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L121-R122) [[3]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L151-R152)

These changes collectively enhance the flexibility and precision of the ETL process, enabling users to migrate only the data that meets specific criteria.