### PR TITLE
refactor: Remove redundant auto-creation message from DynamoDB loader

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -103,7 +103,6 @@ func (l *DynamoLoader) ensureTableExists(ctx context.Context, cfg common.ConfigP
 
 	// Check if auto-approve is enabled.
 	if cfg.GetAutoApprove() {
-		fmt.Printf("Auto-creating table '%s'...\n", l.table)
 		return l.createTable(ctx)
 	}
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -256,7 +256,6 @@ func TestApplyCommand_WithAutoCreateTable(t *testing.T) {
 	// Verify apply command output messages.
 	outputStr := string(output)
 	require.Contains(t, outputStr, "Successfully migrated 1 documents.", "Apply output should show successful migration")
-	require.Contains(t, outputStr, "Auto-creating table 'test_table_auto'...", "Should show auto-creation message")
 	require.Contains(t, outputStr, "Creating DynamoDB table 'test_table_auto'...", "Should show table creation message")
 	require.Contains(t, outputStr, "Waiting for table 'test_table_auto' to become active...", "Should show waiting message")
 	require.Contains(t, outputStr, "Table 'test_table_auto' is now active and ready for use.", "Should show table ready message")


### PR DESCRIPTION
This pull request removes the "Auto-creating table" message from the codebase to streamline log outputs and test expectations. The most important changes include updates to the `ensureTableExists` method in `loader.go` and adjustments to related integration tests.

### Streamlining log outputs:

* [`internal/loader/loader.go`](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL106): Removed the "Auto-creating table" log message from the `ensureTableExists` method to simplify output during table creation.

### Updating test expectations:

* [`test/integration/integration_test.go`](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL259): Updated the `TestApplyCommand_WithAutoCreateTable` test to remove the expectation for the "Auto-creating table" message and ensure alignment with the new log output format.