### PR TITLE
docs: Change code block language from shell to text

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Performs a dry-run to preview the migration by executing the full ETL pipeline w
 - No data is loaded to DynamoDB (dry-run mode)
 
 **Example Output:**
-```shell
+```text
 Starting migration plan analysis...
 Found 1,234 documents to migrate.
 ```
@@ -134,7 +134,7 @@ Executes the complete ETL pipeline to migrate data from MongoDB to DynamoDB.
 - Retry logic for failed operations (configurable via `--max-retries`)
 
 **Example Output:**
-```shell
+```text
 Creating DynamoDB table 'users'...
 Waiting for table 'users' to become active...
 Table 'users' is now active and ready for use.


### PR DESCRIPTION
This pull request updates the `README.md` file to improve the clarity of example outputs by changing the syntax highlighting for code blocks from `shell` to `text`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R120): Changed the syntax highlighting for example outputs in the "dry-run mode" section from `shell` to `text` for better readability.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R137): Updated the syntax highlighting for example outputs in the "complete ETL pipeline execution" section from `shell` to `text` to match the actual output format.