### PR TITLE
perf(extractor): Optimize MongoDB batch size and chunk size for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Features
 
 - **ETL-based Migration**: Complete Extract, Transform, Load pipeline for MongoDB to DynamoDB migration
-- **Batch Processing**: Memory-efficient processing with MongoDB batch size (500) and chunk size (1000) for processing
+- **Batch Processing**: Memory-efficient processing with MongoDB batch size (1000) and chunk size (2000) for processing
 - **MongoDB Filtering**: Selective data extraction using MongoDB query syntax via `--mongo-filter` flag
 - **Automatic Table Creation**: Creates DynamoDB tables automatically with configurable confirmation prompts
 - **Retry Logic**: Robust error handling with exponential backoff and jitter (configurable via `--max-retries`, default: 5)
@@ -130,7 +130,7 @@ Executes the complete ETL pipeline to migrate data from MongoDB to DynamoDB.
 - Full ETL pipeline execution (Extract → Transform → Load)
 - Configuration validation and user confirmation prompts
 - Automatic DynamoDB table creation (with confirmation)
-- Batch processing with fixed chunk sizes (1000 documents per chunk)
+- Batch processing with fixed chunk sizes (2000 documents per chunk)
 - Retry logic for failed operations (configurable via `--max-retries`)
 
 **Example Output:**
@@ -183,7 +183,7 @@ sequenceDiagram
     CLI->>Transformer: Create transformer
     CLI->>CLI: Start migration
     
-    loop For each chunk (1000 docs)
+    loop For each chunk (2000 docs)
         Extractor->>MongoDB: Extract documents
         MongoDB-->>Extractor: Return documents
         Extractor->>Transformer: Transform documents
@@ -201,8 +201,8 @@ sequenceDiagram
 
 - **Connection**: Establishes connection to MongoDB using provided credentials
 - **Filtering**: Applies MongoDB query filters (JSON to BSON conversion)
-- **Batch Processing**: Extracts documents in configurable batches (500 documents per batch)
-- **Chunking**: Groups documents into chunks (1000 documents per chunk) for processing
+- **Batch Processing**: Extracts documents in configurable batches (1000 documents per batch)
+- **Chunking**: Groups documents into chunks (2000 documents per chunk) for processing
 
 ### 2. Transformation
 

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -62,8 +62,8 @@ func (w *mongoCollectionWrapper) Find(ctx context.Context, filter interface{}, o
 func newMongoExtractor(collection Collection, filter primitive.M) *MongoExtractor {
 	return &MongoExtractor{
 		collection: collection,
-		batchSize:  500,
-		chunkSize:  1000,
+		batchSize:  1000,
+		chunkSize:  2000,
 		filter:     filter,
 	}
 }

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -135,7 +135,7 @@ func TestExtractor_Extract_SingleChunk(t *testing.T) {
 
 func TestExtractor_Extract_MultipleChunks(t *testing.T) {
 	mockCollection := new(MockCollection)
-	testDocs := make([]map[string]interface{}, 1500) // More than chunkSize (1000).
+	testDocs := make([]map[string]interface{}, 2500) // More than chunkSize (2000).
 	for i := range testDocs {
 		testDocs[i] = map[string]interface{}{
 			"_id":  i,
@@ -161,7 +161,7 @@ func TestExtractor_Extract_MultipleChunks(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, testDocs, processedDocs)
-	assert.Equal(t, 2, chunkCount) // Should be processed in 2 chunks.
+	assert.Equal(t, 2, chunkCount) // Should be processed in 2 chunks (2000 + 500).
 	mockCollection.AssertExpectations(t)
 	mockCursor.AssertExpectations(t)
 }


### PR DESCRIPTION
This pull request updates the batch and chunk sizes used in the ETL pipeline for MongoDB to DynamoDB migration, increasing them from 500 to 1000 for batch size and from 1000 to 2000 for chunk size. These changes improve memory efficiency and processing throughput. The updates are reflected across documentation, code implementation, and tests.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23): Updated descriptions and examples to reflect the new batch size (1000) and chunk size (2000) for processing. Changes include feature descriptions, pipeline execution details, and sequence diagrams. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R133) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L186-R186) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L204-R205)

### Code Implementation Updates:
* [`internal/extractor/extractor.go`](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L65-R66): Modified the `newMongoExtractor` function to set the batch size to 1000 and chunk size to 2000.

### Test Updates:
* [`internal/extractor/extractor_test.go`](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L138-R138): Updated test cases to accommodate the new chunk size, including adjusting the number of test documents and verifying chunk counts. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L138-R138) [[2]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L164-R164)