### PR TITLE
test(transformer): Add fuzz test for convertID function

### DIFF
--- a/internal/transformer/transformer_fuzz_test.go
+++ b/internal/transformer/transformer_fuzz_test.go
@@ -1,0 +1,33 @@
+package transformer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzConvertID(f *testing.F) {
+	// Seed corpus with various representative values as JSON bytes.
+	f.Add([]byte(`"string_id"`))
+	f.Add([]byte(`42`))
+	f.Add([]byte(`3.14`))
+	f.Add([]byte(`true`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`{"nested": "object"}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Try to unmarshal as JSON to get various input types.
+		var input interface{}
+		if err := json.Unmarshal(data, &input); err != nil {
+			// If JSON unmarshaling fails, use the raw data as string.
+			input = string(data)
+		}
+
+		result := convertID(input)
+
+		// Verify that the result is always a string.
+		if result == "" && input != nil && input != "" {
+			// Empty result is only acceptable for nil or empty string input.
+			t.Errorf("convertID returned empty string for non-empty input: %v", input)
+		}
+	})
+}


### PR DESCRIPTION
This pull request introduces a new fuzz test for the `convertID` function in the `transformer` package. The test ensures the robustness of the `convertID` function by validating its behavior with a wide range of input types and edge cases.

### Testing Improvements:

* [`internal/transformer/transformer_fuzz_test.go`](diffhunk://#diff-c11fbe7626047e693c2a8066c19b7a27901a771d9603ce5f4376e8903c4fc502R1-R33): Added a fuzz test (`FuzzConvertID`) to validate that the `convertID` function consistently converts various input types (e.g., strings, numbers, booleans, null, nested objects) into a string. The test uses JSON unmarshaling for diverse input generation and verifies that the result is non-empty for valid inputs.