### PR TITLE
perf(pool): Implement object pools to reduce memory allocations

### DIFF
--- a/internal/common/pool.go
+++ b/internal/common/pool.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// DocumentPool provides a pool of reusable document maps to reduce memory allocations.
+type DocumentPool struct {
+	pool sync.Pool
+}
+
+// NewDocumentPool creates a new document pool with optimized initial capacity.
+func NewDocumentPool() *DocumentPool {
+	return &DocumentPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				m := make(map[string]interface{}, 10)
+				return &m
+			},
+		},
+	}
+}
+
+// Get retrieves a document map pointer from the pool or creates a new one.
+func (p *DocumentPool) Get() *map[string]interface{} {
+	return p.pool.Get().(*map[string]interface{})
+}
+
+// Put returns a document map pointer to the pool after clearing its contents.
+func (p *DocumentPool) Put(doc *map[string]interface{}) {
+	for k := range *doc {
+		delete(*doc, k)
+	}
+	p.pool.Put(doc)
+}
+
+// ChunkPool provides a pool of reusable document chunks to reduce slice allocations.
+type ChunkPool struct {
+	pool sync.Pool
+	size int
+}
+
+// NewChunkPool creates a new chunk pool with the specified chunk size.
+func NewChunkPool(chunkSize int) *ChunkPool {
+	return &ChunkPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				c := make([]map[string]interface{}, 0, chunkSize)
+				return &c
+			},
+		},
+		size: chunkSize,
+	}
+}
+
+// Get retrieves a document chunk pointer from the pool or creates a new one.
+func (p *ChunkPool) Get() *[]map[string]interface{} {
+	return p.pool.Get().(*[]map[string]interface{})
+}
+
+// Put returns a document chunk pointer to the pool after clearing its contents.
+func (p *ChunkPool) Put(chunk *[]map[string]interface{}) {
+	*chunk = (*chunk)[:0]
+	p.pool.Put(chunk)
+}
+
+// WriteRequestPool provides a pool of reusable DynamoDB write requests.
+type WriteRequestPool struct {
+	pool sync.Pool
+}
+
+// NewWriteRequestPool creates a new write request pool.
+func NewWriteRequestPool() *WriteRequestPool {
+	return &WriteRequestPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				w := make([]types.WriteRequest, 0, 25) // DynamoDB batch size.
+				return &w
+			},
+		},
+	}
+}
+
+// Get retrieves a write request slice pointer from the pool or creates a new one.
+func (p *WriteRequestPool) Get() *[]types.WriteRequest {
+	return p.pool.Get().(*[]types.WriteRequest)
+}
+
+// Put returns a write request slice pointer to the pool after clearing its contents.
+func (p *WriteRequestPool) Put(requests *[]types.WriteRequest) {
+	*requests = (*requests)[:0]
+	p.pool.Put(requests)
+}

--- a/internal/common/pool_test.go
+++ b/internal/common/pool_test.go
@@ -1,0 +1,407 @@
+package common
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocumentPool(t *testing.T) {
+	t.Run("NewDocumentPool", func(t *testing.T) {
+		pool := NewDocumentPool()
+		assert.NotNil(t, pool)
+	})
+
+	t.Run("Get_ReturnsNewMap", func(t *testing.T) {
+		pool := NewDocumentPool()
+		doc := pool.Get()
+
+		assert.NotNil(t, doc)
+		assert.Equal(t, 0, len(*doc))
+		// Maps don't have capacity, so only check length.
+	})
+
+	t.Run("Put_ClearsMap", func(t *testing.T) {
+		pool := NewDocumentPool()
+		doc := pool.Get()
+
+		// Add data to map.
+		*doc = map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		}
+		assert.Equal(t, 2, len(*doc))
+
+		// Return to pool.
+		pool.Put(doc)
+
+		// Get again and check if it's empty.
+		newDoc := pool.Get()
+		assert.Equal(t, 0, len(*newDoc))
+	})
+
+	t.Run("ConcurrentAccess", func(_ *testing.T) {
+		pool := NewDocumentPool()
+		const numGoroutines = 100
+		const operationsPerGoroutine = 10
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < operationsPerGoroutine; j++ {
+					doc := pool.Get()
+					*doc = map[string]interface{}{
+						"test": "value",
+					}
+					pool.Put(doc)
+				}
+			}()
+		}
+
+		wg.Wait()
+		// No race conditions or panics should occur.
+	})
+
+	t.Run("ReuseFromPool", func(t *testing.T) {
+		pool := NewDocumentPool()
+
+		// Get first document.
+		doc1 := pool.Get()
+		*doc1 = map[string]interface{}{"key1": "value1"}
+		pool.Put(doc1)
+
+		// Get second document (may be reused from pool).
+		doc2 := pool.Get()
+		assert.Equal(t, 0, len(*doc2))
+
+		// Address may be different, but content should be empty.
+		*doc2 = map[string]interface{}{"key2": "value2"}
+		pool.Put(doc2)
+	})
+}
+
+func TestChunkPool(t *testing.T) {
+	t.Run("NewChunkPool", func(t *testing.T) {
+		chunkSize := 100
+		pool := NewChunkPool(chunkSize)
+
+		assert.NotNil(t, pool)
+		assert.Equal(t, chunkSize, pool.size)
+	})
+
+	t.Run("Get_ReturnsNewChunk", func(t *testing.T) {
+		chunkSize := 50
+		pool := NewChunkPool(chunkSize)
+		chunk := pool.Get()
+
+		assert.NotNil(t, chunk)
+		assert.Equal(t, 0, len(*chunk))
+		assert.Equal(t, chunkSize, cap(*chunk))
+	})
+
+	t.Run("Put_ClearsChunk", func(t *testing.T) {
+		pool := NewChunkPool(10)
+		chunk := pool.Get()
+
+		// Add data to chunk.
+		*chunk = []map[string]interface{}{
+			{"key1": "value1"},
+			{"key2": "value2"},
+		}
+		assert.Equal(t, 2, len(*chunk))
+
+		// Return to pool.
+		pool.Put(chunk)
+
+		// Get again and check if it's empty.
+		newChunk := pool.Get()
+		assert.Equal(t, 0, len(*newChunk))
+		// Capacity may differ from original due to pool reuse.
+	})
+
+	t.Run("ConcurrentAccess", func(_ *testing.T) {
+		pool := NewChunkPool(20)
+		const numGoroutines = 50
+		const operationsPerGoroutine = 5
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < operationsPerGoroutine; j++ {
+					chunk := pool.Get()
+					*chunk = []map[string]interface{}{
+						{"test": "value"},
+					}
+					pool.Put(chunk)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("ChunkSizeVariations", func(t *testing.T) {
+		testCases := []int{1, 10, 100, 1000}
+
+		for _, size := range testCases {
+			t.Run(fmt.Sprintf("Size_%d", size), func(t *testing.T) {
+				pool := NewChunkPool(size)
+				chunk := pool.Get()
+
+				assert.Equal(t, 0, len(*chunk))
+				assert.Equal(t, size, cap(*chunk))
+
+				pool.Put(chunk)
+			})
+		}
+	})
+}
+
+func TestWriteRequestPool(t *testing.T) {
+	t.Run("NewWriteRequestPool", func(t *testing.T) {
+		pool := NewWriteRequestPool()
+		assert.NotNil(t, pool)
+	})
+
+	t.Run("Get_ReturnsNewSlice", func(t *testing.T) {
+		pool := NewWriteRequestPool()
+		requests := pool.Get()
+
+		assert.NotNil(t, requests)
+		assert.Equal(t, 0, len(*requests))
+		assert.Equal(t, 25, cap(*requests)) // DynamoDB batch size.
+	})
+
+	t.Run("Put_ClearsSlice", func(t *testing.T) {
+		pool := NewWriteRequestPool()
+		requests := pool.Get()
+
+		// Add data to slice.
+		*requests = []types.WriteRequest{
+			{
+				PutRequest: &types.PutRequest{
+					Item: map[string]types.AttributeValue{
+						"id": &types.AttributeValueMemberS{Value: "test"},
+					},
+				},
+			},
+		}
+		assert.Equal(t, 1, len(*requests))
+
+		// Return to pool.
+		pool.Put(requests)
+
+		// Get again and check if it's empty.
+		newRequests := pool.Get()
+		assert.Equal(t, 0, len(*newRequests))
+		// Capacity may differ from original due to pool reuse.
+	})
+
+	t.Run("ConcurrentAccess", func(_ *testing.T) {
+		pool := NewWriteRequestPool()
+		const numGoroutines = 30
+		const operationsPerGoroutine = 3
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < operationsPerGoroutine; j++ {
+					requests := pool.Get()
+					*requests = []types.WriteRequest{
+						{
+							PutRequest: &types.PutRequest{
+								Item: map[string]types.AttributeValue{
+									"id": &types.AttributeValueMemberS{Value: "test"},
+								},
+							},
+						},
+					}
+					pool.Put(requests)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("WriteRequestOperations", func(t *testing.T) {
+		pool := NewWriteRequestPool()
+		requests := pool.Get()
+
+		// Add multiple WriteRequests.
+		*requests = append(*requests, types.WriteRequest{
+			PutRequest: &types.PutRequest{
+				Item: map[string]types.AttributeValue{
+					"id": &types.AttributeValueMemberS{Value: "doc1"},
+				},
+			},
+		})
+
+		*requests = append(*requests, types.WriteRequest{
+			PutRequest: &types.PutRequest{
+				Item: map[string]types.AttributeValue{
+					"id": &types.AttributeValueMemberS{Value: "doc2"},
+				},
+			},
+		})
+
+		assert.Equal(t, 2, len(*requests))
+
+		pool.Put(requests)
+
+		// Verify reuse.
+		newRequests := pool.Get()
+		assert.Equal(t, 0, len(*newRequests))
+	})
+}
+
+func TestPoolMemoryEfficiency(t *testing.T) {
+	t.Run("DocumentPool_MemoryReuse", func(t *testing.T) {
+		pool := NewDocumentPool()
+
+		// Verify memory allocation efficiency with repeated usage.
+		for i := 0; i < 1000; i++ {
+			doc := pool.Get()
+			*doc = map[string]interface{}{
+				"key": "value",
+			}
+			pool.Put(doc)
+		}
+
+		// Verify the last retrieved document is correct.
+		finalDoc := pool.Get()
+		assert.Equal(t, 0, len(*finalDoc))
+		pool.Put(finalDoc)
+	})
+
+	t.Run("ChunkPool_MemoryReuse", func(t *testing.T) {
+		pool := NewChunkPool(100)
+
+		for i := 0; i < 500; i++ {
+			chunk := pool.Get()
+			*chunk = make([]map[string]interface{}, i%10)
+			pool.Put(chunk)
+		}
+
+		finalChunk := pool.Get()
+		assert.Equal(t, 0, len(*finalChunk))
+		// Capacity may differ from original due to pool reuse.
+		pool.Put(finalChunk)
+	})
+
+	t.Run("WriteRequestPool_MemoryReuse", func(t *testing.T) {
+		pool := NewWriteRequestPool()
+
+		for i := 0; i < 200; i++ {
+			requests := pool.Get()
+			*requests = make([]types.WriteRequest, i%5)
+			pool.Put(requests)
+		}
+
+		finalRequests := pool.Get()
+		assert.Equal(t, 0, len(*finalRequests))
+		// Capacity may differ from original due to pool reuse.
+		pool.Put(finalRequests)
+	})
+}
+
+func TestPoolEdgeCases(t *testing.T) {
+	t.Run("DocumentPool_NilPointer", func(t *testing.T) {
+		pool := NewDocumentPool()
+		doc := pool.Get()
+
+		// Should not panic when calling Put with nil pointer.
+		assert.NotPanics(t, func() {
+			pool.Put(doc)
+		})
+	})
+
+	t.Run("ChunkPool_ZeroSize", func(t *testing.T) {
+		pool := NewChunkPool(0)
+		chunk := pool.Get()
+
+		assert.Equal(t, 0, len(*chunk))
+		assert.Equal(t, 0, cap(*chunk))
+
+		pool.Put(chunk)
+	})
+
+	t.Run("ChunkPool_NegativeSize", func(t *testing.T) {
+		// Negative size should cause panic, so verify it panics.
+		assert.Panics(t, func() {
+			pool := NewChunkPool(-1)
+			chunk := pool.Get()
+			pool.Put(chunk)
+		})
+	})
+
+	t.Run("WriteRequestPool_EmptySlice", func(t *testing.T) {
+		pool := NewWriteRequestPool()
+		requests := pool.Get()
+
+		// Call Put with empty slice.
+		assert.NotPanics(t, func() {
+			pool.Put(requests)
+		})
+
+		// Get again and verify.
+		newRequests := pool.Get()
+		assert.Equal(t, 0, len(*newRequests))
+		pool.Put(newRequests)
+	})
+}
+
+func BenchmarkDocumentPool(b *testing.B) {
+	pool := NewDocumentPool()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doc := pool.Get()
+			*doc = map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}
+			pool.Put(doc)
+		}
+	})
+}
+
+func BenchmarkChunkPool(b *testing.B) {
+	pool := NewChunkPool(100)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			chunk := pool.Get()
+			*chunk = make([]map[string]interface{}, 10)
+			pool.Put(chunk)
+		}
+	})
+}
+
+func BenchmarkWriteRequestPool(b *testing.B) {
+	pool := NewWriteRequestPool()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			requests := pool.Get()
+			*requests = make([]types.WriteRequest, 5)
+			pool.Put(requests)
+		}
+	})
+}

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -56,6 +56,7 @@ func newTestLoader(client DBClient, table string, marshal MarshalFunc) *DynamoLo
 		table:      table,
 		marshal:    marshal,
 		maxRetries: defaultMaxRetries,
+		reqPool:    common.NewWriteRequestPool(),
 	}
 }
 


### PR DESCRIPTION
This pull request introduces memory optimization by implementing object pooling for reusable data structures across multiple components. The changes reduce memory allocations and improve performance by reusing maps, slices, and other objects. The updates primarily affect the `common`, `extractor`, `loader`, and `transformer` packages.

### Object Pooling Implementation:

* **`internal/common/pool.go`:** Added three new object pools: `DocumentPool` for reusable document maps, `ChunkPool` for document chunks, and `WriteRequestPool` for DynamoDB write requests. These pools use `sync.Pool` to manage memory efficiently.

### Integration with Extractor:

* **`internal/extractor/extractor.go`:**
  - Introduced a `ChunkPool` in the `MongoExtractor` struct to manage document chunks. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0R35) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0R69)
  - Replaced manual chunk creation with pooled chunks in the `Extract` method, ensuring chunks are cleared and returned to the pool after use. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L148-R150) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L164-R182)

### Integration with Loader:

* **`internal/loader/loader.go`:**
  - Added a `WriteRequestPool` in the `DynamoLoader` struct to manage DynamoDB write requests. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR45) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR55)
  - Updated the `Load` method to use pooled write request slices, ensuring they are cleared and returned to the pool after each batch. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL197-R199) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL220-R225) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR234-R239)

### Integration with Transformer:

* **`internal/transformer/transformer.go`:**
  - Added a `DocumentPool` in the `DocTransformer` struct to manage reusable document maps. [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L19-R21) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L29-R33)
  - Updated the `Transform` method to use pooled maps for transformed documents, returning them to the pool after use. [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L122-L126) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L135-R144)

These changes collectively enhance memory efficiency and reduce garbage collection overhead, particularly in high-throughput scenarios.