### PR TITLE
perf: Add shared memory pools across ETL pipeline components

### DIFF
--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -16,7 +16,7 @@ type Extractor interface {
 // Transformer defines the interface for transforming data between formats.
 type Transformer interface {
 	// Transform transforms the provided documents into a new format.
-	Transform([]map[string]interface{}) ([]map[string]interface{}, error)
+	Transform(ctx context.Context, data []map[string]interface{}) ([]map[string]interface{}, error)
 }
 
 // Loader defines the interface for loading data to a destination.

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -92,7 +92,9 @@ func TestMongoExtractor_Extract_EmptyCollection(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 
 	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
@@ -119,7 +121,9 @@ func TestExtractor_Extract_SingleChunk(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 
 	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
@@ -149,7 +153,9 @@ func TestExtractor_Extract_MultipleChunks(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 	chunkCount := 0
 
@@ -171,7 +177,9 @@ func TestExtractor_Extract_FindError(t *testing.T) {
 	expectedErr := errors.New("find error")
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
 
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
 	})
@@ -193,7 +201,9 @@ func TestExtractor_Extract_DecodeError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockColl.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	mongoExtractor := newMongoExtractor(mockColl, primitive.M{})
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockColl, primitive.M{}, docPool, chunkPool)
 
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
@@ -220,7 +230,9 @@ func TestExtractor_Extract_CallbackError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	expectedErr := errors.New("callback error")
 
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
@@ -246,7 +258,9 @@ func TestExtractor_Extract_CursorError(t *testing.T) {
 	mockCursor.On("Err").Return(expectedErr)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
 	})
@@ -276,7 +290,9 @@ func TestExtractor_Extract_WithFilter(t *testing.T) {
 	expectedFilter := primitive.M{"status": "active"}
 	mockCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).Return(mockCursor, nil)
 
-	mongoExtractor := newMongoExtractor(mockCollection, expectedFilter)
+	docPool := common.NewDocumentPool()
+	chunkPool := common.NewChunkPool(2000)
+	mongoExtractor := newMongoExtractor(mockCollection, expectedFilter, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 
 	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -56,6 +56,8 @@ func newTestLoader(client DBClient, table string, marshal MarshalFunc) *DynamoLo
 		table:      table,
 		marshal:    marshal,
 		maxRetries: defaultMaxRetries,
+		docPool:    common.NewDocumentPool(),
+		chunkPool:  common.NewChunkPool(1000),
 	}
 }
 

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -1,6 +1,7 @@
 package transformer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -34,7 +35,7 @@ func TestDocTransformer_Transform(t *testing.T) {
 			k := r.Intn(j + 1)
 			shuffled[j], shuffled[k] = shuffled[k], shuffled[j]
 		}
-		output, err := docTransformer.Transform(shuffled)
+		output, err := docTransformer.Transform(context.Background(), shuffled)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -81,7 +82,7 @@ func TestDocTransformer_Transform(t *testing.T) {
 func TestDocTransformer_Transform_EmptyInput(t *testing.T) {
 	docTransformer := NewDocTransformer()
 	input := []map[string]interface{}{}
-	output, err := docTransformer.Transform(input)
+	output, err := docTransformer.Transform(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -220,7 +221,7 @@ func TestDocTransformer_Transform_LargeDataset(t *testing.T) {
 		}
 	}
 
-	output, err := docTransformer.Transform(input)
+	output, err := docTransformer.Transform(context.Background(), input)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -280,7 +281,7 @@ func TestDocTransformer_Transform_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			results[idx], errors[idx] = docTransformer.Transform(input)
+			results[idx], errors[idx] = docTransformer.Transform(context.Background(), input)
 		}(i)
 	}
 
@@ -320,7 +321,7 @@ func TestDocTransformer_Transform_WorkerScaling(t *testing.T) {
 		}
 	}
 
-	output, err := docTransformer.Transform(input)
+	output, err := docTransformer.Transform(context.Background(), input)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
This pull request introduces shared memory pools to optimize resource usage and improve concurrency in the MongoDB-to-DynamoDB migration pipeline. It modifies the extractor, transformer, and loader components to utilize these pools, adds a document counting feature to the extractor, and updates tests accordingly.

### Resource Pool Integration:
* Introduced `DocumentPool` and `ChunkPool` for shared memory management across the pipeline. These pools are now used in `mongoExtractor`, `docTransformer`, and `dynamoLoader` to reduce memory allocation overhead. (`cmd/apply/apply.go` [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL91-R115) `cmd/plan/plan.go` [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L72-R93) `internal/extractor/extractor.go` [[3]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L63-R71) `internal/loader/loader.go` [[4]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR57-R70) `internal/transformer/transformer.go` [[5]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L29-R50)

### Enhanced Extractor:
* Added a `Count` method to `MongoExtractor` to determine the total number of documents matching the filter before processing. This helps avoid unnecessary pipeline execution if no documents are found. (`internal/extractor/extractor.go` [internal/extractor/extractor.goL90-R129](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L90-R129))
* Refactored `NewMongoExtractor` to include pool support and introduced `NewMongoExtractorWithPools` for external pool management. (`internal/extractor/extractor.go` [internal/extractor/extractor.goL90-R129](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L90-R129))

### Transformer Updates:
* Updated the `Transform` method in `DocTransformer` to accept a `context.Context` parameter for better cancellation handling and concurrency control. (`internal/transformer/transformer.go` [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L73-R83) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L150-R160)
* Added a new constructor, `NewDocTransformerWithPools`, to allow external pool injection. (`internal/transformer/transformer.go` [internal/transformer/transformer.goL29-R50](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L29-R50))

### Loader Enhancements:
* Refactored `DynamoLoader` to use shared memory pools and added `NewDynamoLoaderWithPools` for external pool management. (`internal/loader/loader.go` [internal/loader/loader.goR91-R107](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR91-R107))
* Ensured resources are returned to the pools after processing to avoid memory leaks. (`internal/loader/loader.go` [internal/loader/loader.goR231-R241](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR231-R241))

### Test Updates:
* Updated all relevant tests to use the new constructors with shared pools, ensuring compatibility with the refactored components. (`internal/extractor/extractor_test.go` [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L95-R97) `internal/transformer/transformer_test.go` [[2]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005R4) `internal/loader/loader_test.go` [[3]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403R59-R60)