### PR TITLE
refactor: Extract memory pool to separate package

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -14,6 +14,7 @@ import (
 	"mongo2dynamo/internal/extractor"
 	"mongo2dynamo/internal/flags"
 	"mongo2dynamo/internal/loader"
+	"mongo2dynamo/internal/pool"
 	"mongo2dynamo/internal/transformer"
 )
 
@@ -89,8 +90,8 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Create shared memory pools for the entire pipeline.
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(1000) // Default chunk size.
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(1000) // Default chunk size.
 
 	// Create mongoExtractor using configuration and shared pools.
 	mongoExtractor, err := extractor.NewMongoExtractorWithPools(cmd.Context(), cfg, docPool, chunkPool)

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -13,6 +13,7 @@ import (
 	"mongo2dynamo/internal/config"
 	"mongo2dynamo/internal/extractor"
 	"mongo2dynamo/internal/flags"
+	"mongo2dynamo/internal/pool"
 	"mongo2dynamo/internal/transformer"
 )
 
@@ -70,8 +71,8 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Create shared memory pools for the entire pipeline.
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(1000) // Default chunk size.
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(1000) // Default chunk size.
 
 	// Create mongoExtractor using configuration and shared pools.
 	mongoExtractor, err := extractor.NewMongoExtractorWithPools(cmd.Context(), cfg, docPool, chunkPool)

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -13,6 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/pool"
 )
 
 // MockCollection is a mock implementation of Collection interface.
@@ -92,8 +93,8 @@ func TestMongoExtractor_Extract_EmptyCollection(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 
@@ -121,8 +122,8 @@ func TestExtractor_Extract_SingleChunk(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 
@@ -153,8 +154,8 @@ func TestExtractor_Extract_MultipleChunks(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 	chunkCount := 0
@@ -177,8 +178,8 @@ func TestExtractor_Extract_FindError(t *testing.T) {
 	expectedErr := errors.New("find error")
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
@@ -201,8 +202,8 @@ func TestExtractor_Extract_DecodeError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockColl.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockColl, primitive.M{}, docPool, chunkPool)
 
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
@@ -230,8 +231,8 @@ func TestExtractor_Extract_CallbackError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	expectedErr := errors.New("callback error")
 
@@ -258,8 +259,8 @@ func TestExtractor_Extract_CursorError(t *testing.T) {
 	mockCursor.On("Err").Return(expectedErr)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
@@ -290,8 +291,8 @@ func TestExtractor_Extract_WithFilter(t *testing.T) {
 	expectedFilter := primitive.M{"status": "active"}
 	mockCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).Return(mockCursor, nil)
 
-	docPool := common.NewDocumentPool()
-	chunkPool := common.NewChunkPool(2000)
+	docPool := pool.NewDocumentPool()
+	chunkPool := pool.NewChunkPool(2000)
 	mongoExtractor := newMongoExtractor(mockCollection, expectedFilter, docPool, chunkPool)
 	var processedDocs []map[string]interface{}
 

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -15,6 +15,7 @@ import (
 
 	"mongo2dynamo/internal/common"
 	"mongo2dynamo/internal/dynamo"
+	"mongo2dynamo/internal/pool"
 )
 
 const (
@@ -43,8 +44,8 @@ type DynamoLoader struct {
 	table      string
 	marshal    MarshalFunc
 	maxRetries int
-	docPool    *common.DocumentPool
-	chunkPool  *common.ChunkPool
+	docPool    *pool.DocumentPool
+	chunkPool  *pool.ChunkPool
 }
 
 // newDynamoLoader creates a new DynamoDB loader.
@@ -54,13 +55,13 @@ func newDynamoLoader(client DBClient, table string, maxRetries int) *DynamoLoade
 		table:      table,
 		marshal:    attributevalue.MarshalMap,
 		maxRetries: maxRetries,
-		docPool:    common.NewDocumentPool(),
-		chunkPool:  common.NewChunkPool(1000),
+		docPool:    pool.NewDocumentPool(),
+		chunkPool:  pool.NewChunkPool(1000),
 	}
 }
 
 // newDynamoLoaderWithPools creates a new DynamoDB loader with external pools.
-func newDynamoLoaderWithPools(client DBClient, table string, maxRetries int, docPool *common.DocumentPool, chunkPool *common.ChunkPool) *DynamoLoader {
+func newDynamoLoaderWithPools(client DBClient, table string, maxRetries int, docPool *pool.DocumentPool, chunkPool *pool.ChunkPool) *DynamoLoader {
 	return &DynamoLoader{
 		client:     client,
 		table:      table,
@@ -89,7 +90,7 @@ func NewDynamoLoader(ctx context.Context, cfg common.ConfigProvider) (*DynamoLoa
 }
 
 // NewDynamoLoaderWithPools creates a DynamoLoader with external pools.
-func NewDynamoLoaderWithPools(ctx context.Context, cfg common.ConfigProvider, docPool *common.DocumentPool, chunkPool *common.ChunkPool) (*DynamoLoader, error) {
+func NewDynamoLoaderWithPools(ctx context.Context, cfg common.ConfigProvider, docPool *pool.DocumentPool, chunkPool *pool.ChunkPool) (*DynamoLoader, error) {
 	client, err := dynamo.Connect(ctx, cfg)
 	if err != nil {
 		return nil, &common.DatabaseConnectionError{Database: "DynamoDB", Reason: err.Error(), Err: err}

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/pool"
 )
 
 const defaultMaxRetries = 5
@@ -56,8 +57,8 @@ func newTestLoader(client DBClient, table string, marshal MarshalFunc) *DynamoLo
 		table:      table,
 		marshal:    marshal,
 		maxRetries: defaultMaxRetries,
-		docPool:    common.NewDocumentPool(),
-		chunkPool:  common.NewChunkPool(1000),
+		docPool:    pool.NewDocumentPool(),
+		chunkPool:  pool.NewChunkPool(1000),
 	}
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1,4 +1,4 @@
-package common
+package pool
 
 import (
 	"sync"

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,4 +1,4 @@
-package common
+package pool
 
 import (
 	"fmt"

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -12,13 +12,14 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/pool"
 )
 
 // DocTransformer transforms MongoDB documents for DynamoDB.
 // It renames the '_id' field to 'id' and removes the '__v' and '_class' fields.
 type DocTransformer struct {
-	docPool   *common.DocumentPool
-	chunkPool *common.ChunkPool
+	docPool   *pool.DocumentPool
+	chunkPool *pool.ChunkPool
 }
 
 // skipFields lists field names to be excluded from the output.
@@ -30,8 +31,8 @@ var skipFields = map[string]struct{}{
 // newDocTransformer creates a new DocTransformer with default pools.
 func newDocTransformer() *DocTransformer {
 	return &DocTransformer{
-		docPool:   common.NewDocumentPool(),
-		chunkPool: common.NewChunkPool(1000),
+		docPool:   pool.NewDocumentPool(),
+		chunkPool: pool.NewChunkPool(1000),
 	}
 }
 
@@ -41,7 +42,7 @@ func NewDocTransformer() common.Transformer {
 }
 
 // NewDocTransformerWithPools creates a new DocTransformer with external pools.
-func NewDocTransformerWithPools(docPool *common.DocumentPool, chunkPool *common.ChunkPool) *DocTransformer {
+func NewDocTransformerWithPools(docPool *pool.DocumentPool, chunkPool *pool.ChunkPool) *DocTransformer {
 	return &DocTransformer{
 		docPool:   docPool,
 		chunkPool: chunkPool,


### PR DESCRIPTION
This pull request refactors the `mongo2dynamo` codebase to move memory pool management from the `common` package to a new `pool` package. The changes update all references to the memory pools (`DocumentPool` and `ChunkPool`) across the codebase, ensuring consistency and modularity. The most important changes include renaming and relocating the pool-related files, updating imports and references in the main application logic, and modifying associated tests.

### Refactoring: Relocation of Memory Pool Code
* `internal/common/pool.go` was renamed to `internal/pool/pool.go`, and its package declaration was updated to `pool`.
* `internal/common/pool_test.go` was renamed to `internal/pool/pool_test.go`, and its package declaration was updated to `pool`.

### Updates to Main Application Logic
* Updated imports and references to `DocumentPool` and `ChunkPool` in `cmd/apply/apply.go` and `cmd/plan/plan.go` to use the new `pool` package. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR17) [[2]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL92-R94) [[3]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R16) [[4]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L73-R75)
* Modified `internal/extractor/extractor.go` to use `pool.DocumentPool` and `pool.ChunkPool` instead of the `common` equivalents. Updated associated functions like `newMongoExtractor` and `NewMongoExtractorWithPools`. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0R14) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L35-R37) [[3]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L64-R65) [[4]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L93-R101)

### Updates to Tests
* Updated imports and references to `DocumentPool` and `ChunkPool` in `internal/extractor/extractor_test.go` to use the `pool` package. Modified all test cases to reflect the changes. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063R16) [[2]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L95-R97) [[3]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L124-R126) [[4]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L156-R158) [[5]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L180-R182) [[6]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L204-R206) [[7]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L233-R235) [[8]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L261-R263) [[9]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L293-R295)
* Updated `internal/loader/loader_test.go` similarly to use the `pool` package. [[1]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403R16) [[2]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L59-R61)

### Updates to Other Modules
* Updated `internal/loader/loader.go` to use `pool.DocumentPool` and `pool.ChunkPool` in the `DynamoLoader` struct and associated functions. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR18) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL46-R48) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL57-R64) [[4]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL92-R93)
* Updated `internal/transformer/transformer.go` to use the `pool` package for memory pools in the `DocTransformer` struct and related functions. [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R15-R22) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L33-R35) [[3]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L44-R45)

These changes improve code organization by separating memory pool management into its own package, making the codebase more modular and easier to maintain.