### PR TITLE
refactor: Simplify convertID function by removing redundant type cases

### DIFF
--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -54,16 +54,6 @@ func convertID(id interface{}) interface{} {
 	switch v := id.(type) {
 	case primitive.ObjectID:
 		return v.Hex()
-	case string:
-		return v
-	case int, int32, int64, uint, uint32, uint64:
-		return v
-	case float32, float64:
-		return v
-	case bool:
-		return v
-	case nil:
-		return nil
 	case primitive.M:
 		// Convert MongoDB primitive.M objects to JSON string.
 		jsonBytes, err := json.Marshal(v)
@@ -73,12 +63,9 @@ func convertID(id interface{}) interface{} {
 		}
 		return string(jsonBytes)
 	default:
-		// For other types, try JSON marshaling first, then fallback to string.
-		jsonBytes, err := json.Marshal(v)
-		if err != nil {
-			return fmt.Sprintf("%v", v)
-		}
-		return string(jsonBytes)
+		// All other types (string, numbers, bool, etc.) pass through unchanged.
+		// DynamoDB will handle type conversion automatically.
+		return v
 	}
 }
 

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -123,11 +123,6 @@ func TestConvertID(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "nil conversion",
-			input:    nil,
-			expected: nil,
-		},
-		{
 			name: "primitive.M conversion",
 			input: primitive.M{
 				"user": "some user",


### PR DESCRIPTION
This pull request refactors the `convertID` function in `internal/transformer/transformer.go` to simplify its logic and improve compatibility with DynamoDB, while also updating the associated test cases. The most important changes include removing explicit type handling for common data types and adjusting the test cases accordingly.

### Refactoring of `convertID` function:
* Removed explicit handling of common types such as `string`, `int`, `float`, `bool`, and `nil`. These types now pass through unchanged, relying on DynamoDB's automatic type conversion. (`internal/transformer/transformer.go`, [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L57-L66) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L76-R68)
* Simplified the default case to eliminate unnecessary JSON marshaling and string conversion for unhandled types. (`internal/transformer/transformer.go`, [internal/transformer/transformer.goL76-R68](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L76-R68))

### Updates to test cases:
* Removed the test case for `nil` conversion, as the explicit handling of `nil` was removed in the function. (`internal/transformer/transformer_test.go`, [internal/transformer/transformer_test.goL125-L129](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L125-L129))