### PR TITLE
refactor: Remove DocumentPool architecture

### DIFF
--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -13,7 +13,6 @@ import (
 	"mongo2dynamo/internal/config"
 	"mongo2dynamo/internal/extractor"
 	"mongo2dynamo/internal/flags"
-	"mongo2dynamo/internal/pool"
 	"mongo2dynamo/internal/transformer"
 )
 
@@ -70,12 +69,8 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("configuration validation failed: %w", err)
 	}
 
-	// Create shared memory pools for the entire pipeline.
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(1000) // Default chunk size.
-
-	// Create mongoExtractor using configuration and shared pools.
-	mongoExtractor, err := extractor.NewMongoExtractorWithPools(cmd.Context(), cfg, docPool, chunkPool)
+	// Create mongoExtractor using configuration.
+	mongoExtractor, err := extractor.NewMongoExtractor(cmd.Context(), cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create MongoDB extractor: %w", err)
 	}
@@ -90,8 +85,8 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// Create docTransformer for MongoDB to DynamoDB document conversion with shared pools.
-	docTransformer := transformer.NewDocTransformerWithPools(docPool, chunkPool)
+	// Create docTransformer for MongoDB to DynamoDB document conversion.
+	docTransformer := transformer.NewDocTransformer()
 
 	// Use a cancellable context to shut down the pipeline on error.
 	ctx, cancel := context.WithCancel(cmd.Context())

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -11,6 +11,8 @@ type ChunkHandler func([]map[string]interface{}) error
 type Extractor interface {
 	// Extract retrieves data from the source and processes it chunk by chunk using the provided callback.
 	Extract(ctx context.Context, handleChunk ChunkHandler) error
+	// Count returns the total number of documents that match the filter.
+	Count(ctx context.Context) (int64, error)
 }
 
 // Transformer defines the interface for transforming data between formats.

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -13,7 +13,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"mongo2dynamo/internal/common"
-	"mongo2dynamo/internal/pool"
 )
 
 // MockCollection is a mock implementation of Collection interface.
@@ -93,9 +92,7 @@ func TestMongoExtractor_Extract_EmptyCollection(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
 	var processedDocs []map[string]interface{}
 
 	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
@@ -122,9 +119,7 @@ func TestExtractor_Extract_SingleChunk(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
 	var processedDocs []map[string]interface{}
 
 	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {
@@ -154,9 +149,7 @@ func TestExtractor_Extract_MultipleChunks(t *testing.T) {
 	mockCursor.On("Err").Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
 	var processedDocs []map[string]interface{}
 	chunkCount := 0
 
@@ -178,9 +171,7 @@ func TestExtractor_Extract_FindError(t *testing.T) {
 	expectedErr := errors.New("find error")
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
 	})
@@ -202,9 +193,7 @@ func TestExtractor_Extract_DecodeError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockColl.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockColl, primitive.M{}, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockColl, primitive.M{})
 
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
@@ -231,9 +220,7 @@ func TestExtractor_Extract_CallbackError(t *testing.T) {
 	mockCursor.On("Close", mock.Anything).Return(nil)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
 	expectedErr := errors.New("callback error")
 
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
@@ -259,9 +246,7 @@ func TestExtractor_Extract_CursorError(t *testing.T) {
 	mockCursor.On("Err").Return(expectedErr)
 	mockCollection.On("Find", mock.Anything, mock.Anything, mock.Anything).Return(mockCursor, nil)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{}, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockCollection, primitive.M{})
 	err := mongoExtractor.Extract(context.Background(), func(_ []map[string]interface{}) error {
 		return nil
 	})
@@ -291,9 +276,7 @@ func TestExtractor_Extract_WithFilter(t *testing.T) {
 	expectedFilter := primitive.M{"status": "active"}
 	mockCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).Return(mockCursor, nil)
 
-	docPool := pool.NewDocumentPool()
-	chunkPool := pool.NewChunkPool(2000)
-	mongoExtractor := newMongoExtractor(mockCollection, expectedFilter, docPool, chunkPool)
+	mongoExtractor := newMongoExtractor(mockCollection, expectedFilter)
 	var processedDocs []map[string]interface{}
 
 	err := mongoExtractor.Extract(context.Background(), func(chunk []map[string]interface{}) error {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"mongo2dynamo/internal/common"
-	"mongo2dynamo/internal/pool"
 )
 
 const defaultMaxRetries = 5
@@ -57,8 +56,6 @@ func newTestLoader(client DBClient, table string, marshal MarshalFunc) *DynamoLo
 		table:      table,
 		marshal:    marshal,
 		maxRetries: defaultMaxRetries,
-		docPool:    pool.NewDocumentPool(),
-		chunkPool:  pool.NewChunkPool(1000),
 	}
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -4,36 +4,6 @@ import (
 	"sync"
 )
 
-// DocumentPool provides a pool of reusable document maps to reduce memory allocations.
-type DocumentPool struct {
-	pool sync.Pool
-}
-
-// NewDocumentPool creates a new document pool with optimized initial capacity.
-func NewDocumentPool() *DocumentPool {
-	return &DocumentPool{
-		pool: sync.Pool{
-			New: func() interface{} {
-				m := make(map[string]interface{}, 10)
-				return &m
-			},
-		},
-	}
-}
-
-// Get retrieves a document map pointer from the pool or creates a new one.
-func (p *DocumentPool) Get() *map[string]interface{} {
-	return p.pool.Get().(*map[string]interface{})
-}
-
-// Put returns a document map pointer to the pool after clearing its contents.
-func (p *DocumentPool) Put(doc *map[string]interface{}) {
-	for k := range *doc {
-		delete(*doc, k)
-	}
-	p.pool.Put(doc)
-}
-
 // ChunkPool provides a pool of reusable document chunks to reduce slice allocations.
 type ChunkPool struct {
 	pool sync.Pool

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -8,83 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDocumentPool(t *testing.T) {
-	t.Run("NewDocumentPool", func(t *testing.T) {
-		pool := NewDocumentPool()
-		assert.NotNil(t, pool)
-	})
-
-	t.Run("Get_ReturnsNewMap", func(t *testing.T) {
-		pool := NewDocumentPool()
-		doc := pool.Get()
-
-		assert.NotNil(t, doc)
-		assert.Equal(t, 0, len(*doc))
-		// Maps don't have capacity, so only check length.
-	})
-
-	t.Run("Put_ClearsMap", func(t *testing.T) {
-		pool := NewDocumentPool()
-		doc := pool.Get()
-
-		// Add data to map.
-		*doc = map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-		}
-		assert.Equal(t, 2, len(*doc))
-
-		// Return to pool.
-		pool.Put(doc)
-
-		// Get again and check if it's empty.
-		newDoc := pool.Get()
-		assert.Equal(t, 0, len(*newDoc))
-	})
-
-	t.Run("ConcurrentAccess", func(_ *testing.T) {
-		pool := NewDocumentPool()
-		const numGoroutines = 100
-		const operationsPerGoroutine = 10
-
-		var wg sync.WaitGroup
-		wg.Add(numGoroutines)
-
-		for i := 0; i < numGoroutines; i++ {
-			go func() {
-				defer wg.Done()
-				for j := 0; j < operationsPerGoroutine; j++ {
-					doc := pool.Get()
-					*doc = map[string]interface{}{
-						"test": "value",
-					}
-					pool.Put(doc)
-				}
-			}()
-		}
-
-		wg.Wait()
-		// No race conditions or panics should occur.
-	})
-
-	t.Run("ReuseFromPool", func(t *testing.T) {
-		pool := NewDocumentPool()
-
-		// Get first document.
-		doc1 := pool.Get()
-		*doc1 = map[string]interface{}{"key1": "value1"}
-		pool.Put(doc1)
-
-		// Get second document (may be reused from pool).
-		doc2 := pool.Get()
-		assert.Equal(t, 0, len(*doc2))
-
-		// Address may be different, but content should be empty.
-		*doc2 = map[string]interface{}{"key2": "value2"}
-		pool.Put(doc2)
-	})
-}
-
 func TestChunkPool(t *testing.T) {
 	t.Run("NewChunkPool", func(t *testing.T) {
 		chunkSize := 100
@@ -165,52 +88,22 @@ func TestChunkPool(t *testing.T) {
 	})
 }
 
-func TestPoolMemoryEfficiency(t *testing.T) {
-	t.Run("DocumentPool_MemoryReuse", func(t *testing.T) {
-		pool := NewDocumentPool()
+func TestChunkPoolMemoryEfficiency(t *testing.T) {
+	pool := NewChunkPool(100)
 
-		// Verify memory allocation efficiency with repeated usage.
-		for i := 0; i < 1000; i++ {
-			doc := pool.Get()
-			*doc = map[string]interface{}{
-				"key": "value",
-			}
-			pool.Put(doc)
-		}
+	for i := 0; i < 500; i++ {
+		chunk := pool.Get()
+		*chunk = make([]map[string]interface{}, i%10)
+		pool.Put(chunk)
+	}
 
-		// Verify the last retrieved document is correct.
-		finalDoc := pool.Get()
-		assert.Equal(t, 0, len(*finalDoc))
-		pool.Put(finalDoc)
-	})
-
-	t.Run("ChunkPool_MemoryReuse", func(t *testing.T) {
-		pool := NewChunkPool(100)
-
-		for i := 0; i < 500; i++ {
-			chunk := pool.Get()
-			*chunk = make([]map[string]interface{}, i%10)
-			pool.Put(chunk)
-		}
-
-		finalChunk := pool.Get()
-		assert.Equal(t, 0, len(*finalChunk))
-		// Capacity may differ from original due to pool reuse.
-		pool.Put(finalChunk)
-	})
+	finalChunk := pool.Get()
+	assert.Equal(t, 0, len(*finalChunk))
+	// Capacity may differ from original due to pool reuse.
+	pool.Put(finalChunk)
 }
 
-func TestPoolEdgeCases(t *testing.T) {
-	t.Run("DocumentPool_NilPointer", func(t *testing.T) {
-		pool := NewDocumentPool()
-		doc := pool.Get()
-
-		// Should not panic when calling Put with nil pointer.
-		assert.NotPanics(t, func() {
-			pool.Put(doc)
-		})
-	})
-
+func TestChunkPoolEdgeCases(t *testing.T) {
 	t.Run("ChunkPool_ZeroSize", func(t *testing.T) {
 		pool := NewChunkPool(0)
 		chunk := pool.Get()
@@ -228,35 +121,5 @@ func TestPoolEdgeCases(t *testing.T) {
 			chunk := pool.Get()
 			pool.Put(chunk)
 		})
-	})
-}
-
-func BenchmarkDocumentPool(b *testing.B) {
-	pool := NewDocumentPool()
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			doc := pool.Get()
-			*doc = map[string]interface{}{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "value3",
-			}
-			pool.Put(doc)
-		}
-	})
-}
-
-func BenchmarkChunkPool(b *testing.B) {
-	pool := NewChunkPool(100)
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			chunk := pool.Get()
-			*chunk = make([]map[string]interface{}, 10)
-			pool.Put(chunk)
-		}
 	})
 }


### PR DESCRIPTION
This pull request introduces significant updates to the `mongo2dynamo` project, focusing on improving memory management, optimizing the ETL pipeline, and simplifying the codebase by removing shared memory pools. The changes enhance performance, reliability, and maintainability, while also updating the documentation to reflect these improvements.

### Documentation Updates
* Updated `README.md` to describe the new memory allocation strategies, real-time worker scaling, and other optimizations for the ETL pipeline. Added details about intelligent field processing and automatic DynamoDB table management. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R135) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R158) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L195-R215)

### Memory Management Simplifications
* Removed the `DocumentPool` and `ChunkPool` shared memory pools from the ETL pipeline. Memory allocation is now handled independently by each component, with `ChunkPool` instantiated locally in the extractor where necessary. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL17) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L36) [[3]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L64-R70) [[4]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L93-R91)

### Code Refactoring
* Simplified the creation of ETL pipeline components (`Extractor`, `Transformer`, and `Loader`) by removing methods that required shared memory pools. Updated corresponding calls in `cmd/apply/apply.go` and `cmd/plan/plan.go`. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL92-R92) [[2]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL112-R111) [[3]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L73-R73) [[4]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L93-R89)

### New Features
* Added a `Count` method to the `Extractor` interface to retrieve the total number of documents matching a filter, enabling better progress tracking.

### Test Updates
* Updated unit tests in `internal/extractor/extractor_test.go` to align with the removal of shared memory pools. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L96-R95) [[2]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L125-R122) [[3]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L157-R152) [[4]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L181-R174) [[5]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L205-R196) [[6]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L234-R223) [[7]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L262-R249)