### PR TITLE
refactor(loader): Simplify backoff calculation using min

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -275,13 +275,8 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]interface{}) 
 
 // calculateBackoffWithJitter calculates exponential backoff with jitter to prevent thundering herd.
 func calculateBackoffWithJitter(attempt int) time.Duration {
-	// Exponential backoff calculation.
-	exponentialDelay := time.Duration(1<<attempt) * baseDelay
-
-	// Cap at maximum delay before applying jitter.
-	if maxDelay < exponentialDelay {
-		exponentialDelay = maxDelay
-	}
+	// Exponential backoff calculation, capped at maxDelay.
+	exponentialDelay := min(time.Duration(1<<attempt)*baseDelay, maxDelay)
 
 	// Add jitter (0.5 ~ 1.5 range) to prevent synchronized retries.
 	jitter := 0.5 + randomSource.Float64()*1.0


### PR DESCRIPTION
This pull request includes a refactor to simplify the exponential backoff calculation in the `calculateBackoffWithJitter` function within the `DynamoLoader` implementation.

Refactoring for simplicity:

* [`internal/loader/loader.go`](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL278-R279): Simplified the calculation of exponential backoff by replacing the conditional logic with the `min` function to cap the delay at `maxDelay`. This refactor improves readability and reduces code complexity.