### PR TITLE
refactor(loader): Decouple DynamoLoader by returning common.Loader

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -29,9 +29,9 @@ var randomSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // DBClient defines the interface for DynamoDB operations used by Loader.
 type DBClient interface {
-	BatchWriteItem(ctx context.Context, params *dynamodb.BatchWriteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error)
-	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
 	CreateTable(ctx context.Context, params *dynamodb.CreateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error)
+	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
+	BatchWriteItem(ctx context.Context, params *dynamodb.BatchWriteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error)
 }
 
 // MarshalFunc defines the interface for marshaling items to DynamoDB format.
@@ -56,7 +56,7 @@ func newDynamoLoader(client DBClient, table string, maxRetries int) *DynamoLoade
 }
 
 // NewDynamoLoader creates a DynamoLoader for DynamoDB based on the configuration.
-func NewDynamoLoader(ctx context.Context, cfg common.ConfigProvider) (*DynamoLoader, error) {
+func NewDynamoLoader(ctx context.Context, cfg common.ConfigProvider) (common.Loader, error) {
 	client, err := dynamo.Connect(ctx, cfg)
 	if err != nil {
 		return nil, &common.DatabaseConnectionError{Database: "DynamoDB", Reason: err.Error(), Err: err}


### PR DESCRIPTION
This pull request introduces several improvements to the `DynamoLoader` implementation and its associated tests. Key changes include refactoring the `DBClient` interface, enhancing error handling and mocking in tests, and improving test coverage for edge cases such as retries, unprocessed items, and context cancellation.

### Refactoring and Interface Updates:
* The `DBClient` interface in `internal/loader/loader.go` was reordered for clarity, moving `DescribeTable` and `BatchWriteItem` after `CreateTable`. This change improves readability and aligns the order with typical usage patterns.
* Updated the `NewDynamoLoader` function to return a `common.Loader` interface instead of a concrete `*DynamoLoader`. This change enhances flexibility and abstraction.

### Mocking and Error Handling Enhancements:
* Improved the `MockDBClient` implementation in `internal/loader/loader_test.go` to handle type assertions more gracefully and provide clearer error messages during testing.
* Enhanced error validation in tests using `require.Error` and `require.ErrorAs` for stricter assertions, ensuring better test reliability.

### Test Coverage Improvements:
* Added new tests for `ensureTableExists` to validate table creation and handling of already existing tables. These tests improve confidence in the table setup logic.
* Refined tests for `Load` functionality, including scenarios for exact batch sizes, batch size exceeding limits, retries for unprocessed items, and context cancellation. These updates ensure comprehensive coverage of edge cases. [[1]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L123-R236) [[2]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403L246-R336)