### PR TITLE
test(flags): Enhance test coverage and validation logic

### DIFF
--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -49,6 +49,22 @@ func TestAddDynamoFlags(t *testing.T) {
 	tableFlag := cmd.Flags().Lookup("dynamo-table")
 	assert.NotNil(t, tableFlag, "dynamo-table flag should be registered")
 
+	partitionKeyFlag := cmd.Flags().Lookup("dynamo-partition-key")
+	assert.NotNil(t, partitionKeyFlag, "dynamo-partition-key flag should be registered")
+	assert.Equal(t, "id", partitionKeyFlag.DefValue)
+
+	partitionKeyTypeFlag := cmd.Flags().Lookup("dynamo-partition-key-type")
+	assert.NotNil(t, partitionKeyTypeFlag, "dynamo-partition-key-type flag should be registered")
+	assert.Equal(t, "S", partitionKeyTypeFlag.DefValue)
+
+	sortKeyFlag := cmd.Flags().Lookup("dynamo-sort-key")
+	assert.NotNil(t, sortKeyFlag, "dynamo-sort-key flag should be registered")
+	assert.Equal(t, "", sortKeyFlag.DefValue)
+
+	sortKeyTypeFlag := cmd.Flags().Lookup("dynamo-sort-key-type")
+	assert.NotNil(t, sortKeyTypeFlag, "dynamo-sort-key-type flag should be registered")
+	assert.Equal(t, "S", sortKeyTypeFlag.DefValue)
+
 	regionFlag := cmd.Flags().Lookup("aws-region")
 	assert.NotNil(t, regionFlag, "aws-region flag should be registered")
 	assert.Equal(t, "us-east-1", regionFlag.DefValue)


### PR DESCRIPTION
This pull request adds test coverage for new DynamoDB-related flags in the `TestAddDynamoFlags` function. The tests ensure that these flags are properly registered and have the correct default values.

### Added test cases for new DynamoDB flags:
* Verified the registration and default value of the `dynamo-partition-key` flag (`id`).
* Verified the registration and default value of the `dynamo-partition-key-type` flag (`S`).
* Verified the registration and default value of the `dynamo-sort-key` flag (empty string).
* Verified the registration and default value of the `dynamo-sort-key-type` flag (`S`).