### PR TITLE
refactor(transformer): Use switch statement for field skipping

### DIFF
--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -12,11 +12,6 @@ import (
 	"mongo2dynamo/internal/worker"
 )
 
-var skipFields = map[string]struct{}{
-	"__v":    {},
-	"_class": {},
-}
-
 // DocTransformer transforms MongoDB documents.
 type DocTransformer struct{}
 
@@ -46,14 +41,14 @@ func (t *DocTransformer) Transform(
 
 		newDoc := make(map[string]interface{}, estimatedFields)
 		for k, v := range doc {
-			if k == "_id" {
+			switch k {
+			case "_id":
 				newDoc["id"] = convertID(v)
+			case "__v", "_class":
 				continue
+			default:
+				newDoc[k] = v
 			}
-			if _, skip := skipFields[k]; skip {
-				continue
-			}
-			newDoc[k] = v
 		}
 		return worker.Result[map[string]interface{}]{JobID: job.ID, Value: newDoc}
 	}


### PR DESCRIPTION
This pull request refactors the `DocTransformer` logic in `internal/transformer/transformer.go` to simplify the handling of fields that need to be skipped during document transformation. The key changes involve removing the `skipFields` map and replacing it with a `switch` statement for better readability and efficiency.

### Refactoring of field skipping logic:

* Removed the `skipFields` map, which previously stored fields to be skipped (`"__v"` and `"_class"`). This logic is now handled directly in the `switch` statement inside the `Transform` method. (`internal/transformer/transformer.go`, [internal/transformer/transformer.goL15-L19](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L15-L19))
* Updated the `Transform` method to use a `switch` statement for field handling. Fields `"__v"` and `"_class"` are explicitly skipped, while the `_id` field is converted to `"id"`, and all other fields are copied as-is. (`internal/transformer/transformer.go`, [internal/transformer/transformer.goL49-R52](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L49-R52))