### PR TITLE
refactor: Remove unused confirmation handling

### DIFF
--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -62,10 +62,6 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 
 	// Validate configuration after all values are set.
 	if err := cfg.Validate(); err != nil {
-		if errors.Is(err, context.Canceled) {
-			fmt.Println("Plan canceled by user (table name confirmation declined).")
-			return nil
-		}
 		return fmt.Errorf("configuration validation failed: %w", err)
 	}
 


### PR DESCRIPTION
This pull request modifies the error handling in the `runPlan` function to simplify the code and remove specific handling for user-canceled operations.

### Error handling changes:
* [`cmd/plan/plan.go`](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L65-L68): Removed the special case for handling `context.Canceled` errors during configuration validation, streamlining the error handling logic.