### PR TITLE
docs: Add partition key and sort key examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,12 @@ export MONGO2DYNAMO_MONGO_PASSWORD=your_password
 export MONGO2DYNAMO_MONGO_DB=your_database
 export MONGO2DYNAMO_MONGO_COLLECTION=your_collection
 export MONGO2DYNAMO_MONGO_FILTER='{"status": "active"}'
-export MONGO2DYNAMO_DYNAMO_TABLE=your_table
 export MONGO2DYNAMO_DYNAMO_ENDPOINT=http://localhost:8000
+export MONGO2DYNAMO_DYNAMO_TABLE=your_table
+export MONGO2DYNAMO_DYNAMO_PARTITION_KEY=id
+export MONGO2DYNAMO_DYNAMO_PARTITION_KEY_TYPE=S
+export MONGO2DYNAMO_DYNAMO_SORT_KEY=timestamp
+export MONGO2DYNAMO_DYNAMO_SORT_KEY_TYPE=N
 export MONGO2DYNAMO_AWS_REGION=us-east-1
 export MONGO2DYNAMO_MAX_RETRIES=5
 export MONGO2DYNAMO_AUTO_APPROVE=false
@@ -142,8 +146,12 @@ mongo_password: your_password
 mongo_db: your_database
 mongo_collection: your_collection
 mongo_filter: '{"status": "active"}'
-dynamo_table: your_table
 dynamo_endpoint: http://localhost:8000
+dynamo_table: your_table
+dynamo_partition_key: id
+dynamo_partition_key_type: S
+dynamo_sort_key: timestamp
+dynamo_sort_key_type: N
 aws_region: us-east-1
 max_retries: 5
 auto_approve: false


### PR DESCRIPTION
This pull request updates the `README.md` file to include additional configuration options for DynamoDB integration. The changes ensure that users can specify partition and sort key details for DynamoDB tables in both environment variable and YAML configuration formats.

### Updates to DynamoDB Configuration:

* Added environment variables for specifying the partition key (`MONGO2DYNAMO_DYNAMO_PARTITION_KEY`), partition key type (`MONGO2DYNAMO_DYNAMO_PARTITION_KEY_TYPE`), sort key (`MONGO2DYNAMO_DYNAMO_SORT_KEY`), and sort key type (`MONGO2DYNAMO_DYNAMO_SORT_KEY_TYPE`) in the environment variable configuration section.
* Added corresponding YAML configuration options for the partition key (`dynamo_partition_key`), partition key type (`dynamo_partition_key_type`), sort key (`dynamo_sort_key`), and sort key type (`dynamo_sort_key_type`) in the YAML configuration section.