### PR TITLE
refactor: Scope auto-approve flag to apply command only

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,21 +97,20 @@ Configuration can be provided via command-line flags, environment variables, or 
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--dynamo-table` | DynamoDB table name. | MongoDB collection name |
 | `--dynamo-endpoint` | DynamoDB endpoint. | `http://localhost:8000` |
-| `--aws-region` | AWS region. | `us-east-1` |
+| `--dynamo-table` | DynamoDB table name. | MongoDB collection name |
 | `--dynamo-partition-key` | The attribute name for the partition key. | `id` |
 | `--dynamo-partition-key-type` | The attribute type for the partition key (S, N, B). | `S` |
 | `--dynamo-sort-key` | The attribute name for the sort key. (Optional) | ` ` |
 | `--dynamo-sort-key-type` | The attribute type for the sort key (S, N, B). | `S` |
+| `--aws-region` | AWS region. | `us-east-1` |
+| `--max-retries` | Maximum retries for failed DynamoDB batch writes. | `5` |
 
-**General Flags**
+**Apply Control Flags**
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--max-retries` | Maximum retries for failed DynamoDB batch writes. | `5` |
 | `--auto-approve` | Skip all confirmation prompts. | `false` |
-| `-h`, `--help` | Show help for a command. | ` ` |
 
 ### Environment Variables
 

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -214,4 +214,5 @@ func init() {
 	// Add flags.
 	flags.AddMongoFlags(ApplyCmd)
 	flags.AddDynamoFlags(ApplyCmd)
+	flags.AddAutoApproveFlag(ApplyCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"mongo2dynamo/cmd/apply"
 	"mongo2dynamo/cmd/plan"
@@ -26,22 +25,8 @@ func Execute() {
 	}
 }
 
-func bindPersistentFlags() {
-	if err := viper.BindPFlag("auto-approve", rootCmd.PersistentFlags().Lookup("auto-approve")); err != nil {
-		rootCmd.PrintErrf("Failed to bind auto-approve flag: %v\n", err)
-		os.Exit(1)
-	}
-}
-
-func initConfig() {
-	viper.AutomaticEnv()
-}
-
 func init() {
-	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().Bool("auto-approve", false, "Skip confirmation prompt")
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-	bindPersistentFlags()
 
 	rootCmd.AddCommand(apply.ApplyCmd)
 	rootCmd.AddCommand(plan.PlanCmd)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -26,3 +26,8 @@ func AddDynamoFlags(cmd *cobra.Command) {
 	cmd.Flags().String("aws-region", "us-east-1", "AWS region.")
 	cmd.Flags().Int("max-retries", 5, "Maximum number of retries for DynamoDB batch write.")
 }
+
+// AddAutoApproveFlag adds the auto-approve flag to the command.
+func AddAutoApproveFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("auto-approve", false, "Skip all confirmation prompts")
+}

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -73,3 +73,12 @@ func TestAddDynamoFlags(t *testing.T) {
 	assert.NotNil(t, maxRetriesFlag, "max-retries flag should be registered")
 	assert.Equal(t, "5", maxRetriesFlag.DefValue)
 }
+
+func TestAddAutoApproveFlag(t *testing.T) {
+	cmd := &cobra.Command{}
+	flags.AddAutoApproveFlag(cmd)
+
+	autoApproveFlag := cmd.Flags().Lookup("auto-approve")
+	assert.NotNil(t, autoApproveFlag, "auto-approve flag should be registered")
+	assert.Equal(t, "false", autoApproveFlag.DefValue)
+}


### PR DESCRIPTION
This pull request introduces updates to the flag management system, documentation, and associated tests. The changes improve the handling of command-line flags, particularly the addition of a new `--auto-approve` flag, and clean up unused dependencies. Below is a summary of the most important changes:

### Flag Management Enhancements:
* Added a new `--auto-approve` flag to skip confirmation prompts. This flag was integrated into the `apply` command (`cmd/apply/apply.go`) and its functionality was implemented in `internal/flags/flags.go`. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR217) [[2]](diffhunk://#diff-dea4d60e02b3dedd8b784f4254501a4ad4cc9d10ad45e5e8962582574c82920fR29-R33)
* Removed the redundant `viper` dependency and associated flag binding logic, simplifying the `root` command initialization (`cmd/root.go`). [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL7) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL29-L44)

### Documentation Updates:
* Updated the `README.md` to include the new `--auto-approve` flag in the "Apply Control Flags" section and reorganized the flag descriptions for better clarity.

### Testing Improvements:
* Added a new unit test for the `AddAutoApproveFlag` function to ensure the `--auto-approve` flag is correctly registered and has the expected default value (`internal/flags/flags_test.go`).