### PR TITLE
misc: Add period to auto-approve flag description

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -30,5 +30,5 @@ func AddDynamoFlags(cmd *cobra.Command) {
 
 // AddAutoApproveFlag adds the auto-approve flag to the command.
 func AddAutoApproveFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("auto-approve", false, "Skip all confirmation prompts")
+	cmd.Flags().Bool("auto-approve", false, "Skip all confirmation prompts.")
 }


### PR DESCRIPTION
This pull request includes a minor change to the `AddAutoApproveFlag` function in the `internal/flags/flags.go` file. The change adds a period at the end of the flag description for consistency.

* [`internal/flags/flags.go`](diffhunk://#diff-dea4d60e02b3dedd8b784f4254501a4ad4cc9d10ad45e5e8962582574c82920fL33-R33): Updated the description of the "auto-approve" flag to include a period for consistency.