### PR TITLE
refactor: Replace all uses of 'interface{}' with 'any'

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -123,8 +123,8 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	// Pipeline channels.
 	const pipelineChannelBufferSize = 10
-	extractChan := make(chan []map[string]interface{}, pipelineChannelBufferSize)
-	transformChan := make(chan []map[string]interface{}, pipelineChannelBufferSize)
+	extractChan := make(chan []map[string]any, pipelineChannelBufferSize)
+	transformChan := make(chan []map[string]any, pipelineChannelBufferSize)
 	errorChan := make(chan error, 3)
 
 	// Use a WaitGroup to wait for all pipeline stages to finish.
@@ -175,7 +175,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	// Stage 1: Extractor.
 	fmt.Println("Starting data migration from MongoDB to DynamoDB...")
-	extractErr := mongoExtractor.Extract(ctx, func(chunk []map[string]interface{}) error {
+	extractErr := mongoExtractor.Extract(ctx, func(chunk []map[string]any) error {
 		select {
 		case extractChan <- chunk:
 			return nil

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -90,7 +90,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 
 	// Pipeline channels.
 	const pipelineChannelBufferSize = 10
-	extractChan := make(chan []map[string]interface{}, pipelineChannelBufferSize)
+	extractChan := make(chan []map[string]any, pipelineChannelBufferSize)
 	errorChan := make(chan error, 2)
 
 	// Use a WaitGroup to wait for all pipeline stages to finish.
@@ -121,7 +121,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 
 	// Stage 1: Extractor.
 	fmt.Println("Starting migration plan analysis...")
-	extractErr := mongoExtractor.Extract(ctx, func(chunk []map[string]interface{}) error {
+	extractErr := mongoExtractor.Extract(ctx, func(chunk []map[string]any) error {
 		select {
 		case extractChan <- chunk:
 			return nil

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ChunkHandler defines the callback type for processing a chunk of documents.
-type ChunkHandler func([]map[string]interface{}) error
+type ChunkHandler func([]map[string]any) error
 
 // Extractor defines the interface for extracting data from a source.
 type Extractor interface {
@@ -18,13 +18,13 @@ type Extractor interface {
 // Transformer defines the interface for transforming data between formats.
 type Transformer interface {
 	// Transform transforms the provided documents into a new format.
-	Transform(ctx context.Context, data []map[string]interface{}) ([]map[string]interface{}, error)
+	Transform(ctx context.Context, data []map[string]any) ([]map[string]any, error)
 }
 
 // Loader defines the interface for loading data to a destination.
 type Loader interface {
 	// Load saves the provided data to the destination.
-	Load(ctx context.Context, data []map[string]interface{}) error
+	Load(ctx context.Context, data []map[string]any) error
 }
 
 // ConfigProvider is the interface for providing configuration settings.

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -16,13 +16,13 @@ import (
 
 // Collection defines the interface for MongoDB collection operations needed by Extractor.
 type Collection interface {
-	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (Cursor, error)
+	Find(ctx context.Context, filter any, opts ...*options.FindOptions) (Cursor, error)
 }
 
 // Cursor defines the interface for MongoDB cursor operations needed by Extractor.
 type Cursor interface {
 	Next(ctx context.Context) bool
-	Decode(val interface{}) error
+	Decode(val any) error
 	Close(ctx context.Context) error
 	Err() error
 }
@@ -48,7 +48,7 @@ type mongoCursorWrapper struct {
 }
 
 // Find executes a MongoDB find operation on the wrapped collection.
-func (w *mongoCollectionWrapper) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (Cursor, error) {
+func (w *mongoCollectionWrapper) Find(ctx context.Context, filter any, opts ...*options.FindOptions) (Cursor, error) {
 	cursor, err := w.Collection.Find(ctx, filter, opts...)
 	if err != nil {
 		return nil, &common.DatabaseOperationError{
@@ -170,7 +170,7 @@ func (e *MongoExtractor) Extract(ctx context.Context, handleChunk common.ChunkHa
 	defer e.chunkPool.Put(chunkPtr)
 
 	for cursor.Next(ctx) {
-		var doc map[string]interface{}
+		var doc map[string]any
 		if err := cursor.Decode(&doc); err != nil {
 			return &common.DataValidationError{
 				Database: "MongoDB",

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -30,7 +30,7 @@ type DBClient interface {
 }
 
 // MarshalFunc defines the interface for marshaling items to DynamoDB format.
-type MarshalFunc func(item interface{}) (map[string]types.AttributeValue, error)
+type MarshalFunc func(item any) (map[string]types.AttributeValue, error)
 
 // DynamoLoader implements the Loader interface for DynamoDB.
 type DynamoLoader struct {
@@ -68,7 +68,7 @@ func NewDynamoLoader(ctx context.Context, cfg common.ConfigProvider) (common.Loa
 }
 
 // marshalItem marshals a single item to DynamoDB format.
-func (l *DynamoLoader) marshalItem(item map[string]interface{}) (map[string]types.AttributeValue, error) {
+func (l *DynamoLoader) marshalItem(item map[string]any) (map[string]types.AttributeValue, error) {
 	return l.marshal(item)
 }
 
@@ -204,7 +204,7 @@ func (l *DynamoLoader) waitForTableActive(ctx context.Context) error {
 }
 
 // Load saves all documents to DynamoDB using a pool of workers.
-func (l *DynamoLoader) Load(ctx context.Context, data []map[string]interface{}) error {
+func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 	if len(data) == 0 {
 		return nil
 	}

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -123,7 +123,7 @@ func TestDynamoLoader_Load_Success(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
 
-	data := []map[string]interface{}{{"id": "1", "name": "test1"}}
+	data := []map[string]any{{"id": "1", "name": "test1"}}
 
 	mockClient.On("BatchWriteItem", mock.Anything, mock.Anything).Return(&dynamodb.BatchWriteItemOutput{
 		UnprocessedItems: make(map[string][]types.WriteRequest),
@@ -137,7 +137,7 @@ func TestDynamoLoader_Load_Success(t *testing.T) {
 func TestDynamoLoader_Load_ComplexDataTypes(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
-	data := []map[string]interface{}{
+	data := []map[string]any{
 		{
 			"id":        "user123",
 			"age":       30,
@@ -160,7 +160,7 @@ func TestDynamoLoader_Load_EmptyData(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
 
-	err := dynamoLoader.Load(context.Background(), []map[string]interface{}{})
+	err := dynamoLoader.Load(context.Background(), []map[string]any{})
 	assert.NoError(t, err)
 	mockClient.AssertNotCalled(t, "BatchWriteItem")
 }
@@ -168,9 +168,9 @@ func TestDynamoLoader_Load_EmptyData(t *testing.T) {
 func TestDynamoLoader_Load_ExactBatchSize(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
-	data := make([]map[string]interface{}, 25)
+	data := make([]map[string]any, 25)
 	for i := 0; i < 25; i++ {
-		data[i] = map[string]interface{}{"id": i, "name": "test"}
+		data[i] = map[string]any{"id": i, "name": "test"}
 	}
 
 	mockClient.On("BatchWriteItem", mock.Anything, mock.MatchedBy(func(input *dynamodb.BatchWriteItemInput) bool {
@@ -185,9 +185,9 @@ func TestDynamoLoader_Load_ExactBatchSize(t *testing.T) {
 func TestDynamoLoader_Load_BatchSizeExceeded(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
-	data := make([]map[string]interface{}, 30)
+	data := make([]map[string]any, 30)
 	for i := 0; i < 30; i++ {
-		data[i] = map[string]interface{}{"id": i, "name": "test"}
+		data[i] = map[string]any{"id": i, "name": "test"}
 	}
 
 	mockClient.On("BatchWriteItem", mock.Anything, mock.MatchedBy(func(input *dynamodb.BatchWriteItemInput) bool {
@@ -205,7 +205,7 @@ func TestDynamoLoader_Load_BatchSizeExceeded(t *testing.T) {
 func TestDynamoLoader_Load_UnprocessedItemsRetry(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
-	data := []map[string]interface{}{
+	data := []map[string]any{
 		{"id": "1", "name": "test1"},
 		{"id": "2", "name": "test2"},
 	}
@@ -232,7 +232,7 @@ func TestDynamoLoader_Load_ExponentialBackoff(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
 
-	data := []map[string]interface{}{
+	data := []map[string]any{
 		{"id": "1", "name": "test1"},
 	}
 
@@ -260,13 +260,13 @@ func TestDynamoLoader_Load_MarshalError(t *testing.T) {
 	mockClient := &MockDBClient{}
 
 	// Mock marshal function that returns an error.
-	mockMarshal := func(_ interface{}) (map[string]types.AttributeValue, error) {
+	mockMarshal := func(_ any) (map[string]types.AttributeValue, error) {
 		return nil, errors.New("marshal error")
 	}
 
 	dynamoLoader := newTestLoader(mockClient, "test-table", mockMarshal)
 
-	data := []map[string]interface{}{
+	data := []map[string]any{
 		{"id": "1", "name": "test1"},
 	}
 
@@ -284,7 +284,7 @@ func TestDynamoLoader_Load_DynamoDBError(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
 	expectedErr := errors.New("dynamodb error")
-	data := []map[string]interface{}{{"id": "1"}}
+	data := []map[string]any{{"id": "1"}}
 
 	mockClient.On("BatchWriteItem", mock.Anything, mock.Anything).Return(nil, expectedErr)
 
@@ -298,7 +298,7 @@ func TestDynamoLoader_Load_DynamoDBError(t *testing.T) {
 func TestDynamoLoader_Load_UnprocessedItemsMaxRetriesExceeded(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", 1) // Only 1 attempt.
-	data := []map[string]interface{}{{"id": "1"}}
+	data := []map[string]any{{"id": "1"}}
 
 	unprocessed := []types.WriteRequest{{PutRequest: &types.PutRequest{Item: map[string]types.AttributeValue{
 		"id": &types.AttributeValueMemberS{Value: "1"},
@@ -318,7 +318,7 @@ func TestDynamoLoader_Load_UnprocessedItemsMaxRetriesExceeded(t *testing.T) {
 func TestDynamoLoader_Load_ContextCancellation(t *testing.T) {
 	mockClient := &MockDBClient{}
 	dynamoLoader := newDynamoLoader(mockClient, "test-table", defaultMaxRetries)
-	data := []map[string]interface{}{{"id": "1"}}
+	data := []map[string]any{{"id": "1"}}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel the context immediately.

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -14,8 +14,8 @@ type ChunkPool struct {
 func NewChunkPool(chunkSize int) *ChunkPool {
 	return &ChunkPool{
 		pool: sync.Pool{
-			New: func() interface{} {
-				c := make([]map[string]interface{}, 0, chunkSize)
+			New: func() any {
+				c := make([]map[string]any, 0, chunkSize)
 				return &c
 			},
 		},
@@ -24,12 +24,12 @@ func NewChunkPool(chunkSize int) *ChunkPool {
 }
 
 // Get retrieves a document chunk pointer from the pool or creates a new one.
-func (p *ChunkPool) Get() *[]map[string]interface{} {
-	return p.pool.Get().(*[]map[string]interface{})
+func (p *ChunkPool) Get() *[]map[string]any {
+	return p.pool.Get().(*[]map[string]any)
 }
 
 // Put returns a document chunk pointer to the pool after clearing its contents.
-func (p *ChunkPool) Put(chunk *[]map[string]interface{}) {
+func (p *ChunkPool) Put(chunk *[]map[string]any) {
 	*chunk = (*chunk)[:0]
 	p.pool.Put(chunk)
 }

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -32,7 +32,7 @@ func TestChunkPool(t *testing.T) {
 		chunk := pool.Get()
 
 		// Add data to chunk.
-		*chunk = []map[string]interface{}{
+		*chunk = []map[string]any{
 			{"key1": "value1"},
 			{"key2": "value2"},
 		}
@@ -60,7 +60,7 @@ func TestChunkPool(t *testing.T) {
 				defer wg.Done()
 				for j := 0; j < operationsPerGoroutine; j++ {
 					chunk := pool.Get()
-					*chunk = []map[string]interface{}{
+					*chunk = []map[string]any{
 						{"test": "value"},
 					}
 					pool.Put(chunk)
@@ -93,7 +93,7 @@ func TestChunkPoolMemoryEfficiency(t *testing.T) {
 
 	for i := 0; i < 500; i++ {
 		chunk := pool.Get()
-		*chunk = make([]map[string]interface{}, i%10)
+		*chunk = make([]map[string]any, i%10)
 		pool.Put(chunk)
 	}
 

--- a/internal/transformer/transformer_fuzz_test.go
+++ b/internal/transformer/transformer_fuzz_test.go
@@ -16,7 +16,7 @@ func FuzzConvertID(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Try to unmarshal as JSON to get various input types.
-		var input interface{}
+		var input any
 		if err := json.Unmarshal(data, &input); err != nil {
 			// If JSON unmarshaling fails, use the raw data as string.
 			input = string(data)

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -15,11 +15,11 @@ import (
 
 func TestDocTransformer_Transform(t *testing.T) {
 	docTransformer := NewDocTransformer()
-	input := []map[string]interface{}{
+	input := []map[string]any{
 		{"_id": "abc123", "__v": 1, "_class": "com.example.MyEntity", "name": "test"},
 		{"_id": "def456", "__v": 2, "name": "test2", "other": 42},
 	}
-	expected := []map[string]interface{}{
+	expected := []map[string]any{
 		{"id": "abc123", "name": "test"},
 		{"id": "def456", "name": "test2", "other": 42},
 	}
@@ -28,7 +28,7 @@ func TestDocTransformer_Transform(t *testing.T) {
 	runs := 10
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < runs; i++ {
-		shuffled := make([]map[string]interface{}, len(input))
+		shuffled := make([]map[string]any, len(input))
 		copy(shuffled, input)
 		// Shuffle the input slice using the local random generator.
 		for j := range shuffled {
@@ -81,7 +81,7 @@ func TestDocTransformer_Transform(t *testing.T) {
 
 func TestDocTransformer_Transform_EmptyInput(t *testing.T) {
 	docTransformer := NewDocTransformer()
-	input := []map[string]interface{}{}
+	input := []map[string]any{}
 	output, err := docTransformer.Transform(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -94,8 +94,8 @@ func TestDocTransformer_Transform_EmptyInput(t *testing.T) {
 func TestConvertID(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
-		expected interface{}
+		input    any
+		expected any
 	}{
 		{
 			name:     "ObjectID conversion",
@@ -177,7 +177,7 @@ func TestConvertID(t *testing.T) {
 					t.Errorf("primitive.M conversion: expected string in test data, got %T", tt.expected)
 					return
 				}
-				var resultMap, expectedMap map[string]interface{}
+				var resultMap, expectedMap map[string]any
 
 				if err := json.Unmarshal([]byte(resultStr), &resultMap); err != nil {
 					t.Errorf("Failed to unmarshal result JSON: %v", err)
@@ -218,9 +218,9 @@ func TestDocTransformer_Transform_LargeDataset(t *testing.T) {
 	docTransformer := NewDocTransformer()
 
 	// Create a large dataset to test dynamic worker scaling.
-	input := make([]map[string]interface{}, 10000)
+	input := make([]map[string]any, 10000)
 	for i := 0; i < 10000; i++ {
-		input[i] = map[string]interface{}{
+		input[i] = map[string]any{
 			"_id":     fmt.Sprintf("id_%d", i),
 			"__v":     i,
 			"_class":  "com.example.Entity",
@@ -271,9 +271,9 @@ func TestDocTransformer_Transform_ConcurrentAccess(t *testing.T) {
 	docTransformer := NewDocTransformer()
 
 	// Create test data.
-	input := make([]map[string]interface{}, 1000)
+	input := make([]map[string]any, 1000)
 	for i := 0; i < 1000; i++ {
-		input[i] = map[string]interface{}{
+		input[i] = map[string]any{
 			"_id":    fmt.Sprintf("id_%d", i),
 			"__v":    i,
 			"_class": "com.example.Entity",
@@ -284,7 +284,7 @@ func TestDocTransformer_Transform_ConcurrentAccess(t *testing.T) {
 	// Run multiple transformations concurrently.
 	numGoroutines := 10
 	var wg sync.WaitGroup
-	results := make([][]map[string]interface{}, numGoroutines)
+	results := make([][]map[string]any, numGoroutines)
 	errors := make([]error, numGoroutines)
 
 	for i := 0; i < numGoroutines; i++ {
@@ -320,9 +320,9 @@ func TestDocTransformer_Transform_WorkerScaling(t *testing.T) {
 	docTransformer := NewDocTransformer()
 
 	// Create a dataset that should trigger worker scaling.
-	input := make([]map[string]interface{}, 5000)
+	input := make([]map[string]any, 5000)
 	for i := 0; i < 5000; i++ {
-		input[i] = map[string]interface{}{
+		input[i] = map[string]any{
 			"_id":    fmt.Sprintf("id_%d", i),
 			"__v":    i,
 			"_class": "com.example.Entity",

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -197,7 +197,7 @@ func TestApplyCommand_WithExistingTable(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result.Item)
 
-	var item map[string]interface{}
+	var item map[string]any
 	err = attributevalue.UnmarshalMap(result.Item, &item)
 	require.NoError(t, err)
 	require.Equal(t, "mongoid-001", item["id"])
@@ -270,7 +270,7 @@ func TestApplyCommand_WithAutoCreateTable(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result.Item)
 
-	var item map[string]interface{}
+	var item map[string]any
 	err = attributevalue.UnmarshalMap(result.Item, &item)
 	require.NoError(t, err)
 	require.Equal(t, "mongoid-001", item["id"])


### PR DESCRIPTION
This pull request replaces the use of `interface{}` with the more specific `any` type across the codebase to improve readability and align with Go's modern conventions. The changes span multiple files, including core logic, interfaces, and tests.

### Core Logic Updates:
* Updated channel and function parameter types in `cmd/apply/apply.go` and `cmd/plan/plan.go` to use `map[string]any` instead of `map[string]interface{}`. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL126-R127) [[2]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL178-R178) [[3]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L93-R93) [[4]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L124-R124)

### Interface and Implementation Changes:
* Changed the `ChunkHandler`, `Extractor`, `Transformer`, and `Loader` interfaces in `internal/common/interfaces.go` to use `any` instead of `interface{}`. [[1]](diffhunk://#diff-fb0402d90a50c88994fc12453ed2c3f545627f1ee4d21ea3a20fc27d8bd36dffL8-R8) [[2]](diffhunk://#diff-fb0402d90a50c88994fc12453ed2c3f545627f1ee4d21ea3a20fc27d8bd36dffL21-R27)
* Updated MongoDB-related interfaces and implementations in `internal/extractor/extractor.go` to replace `interface{}` with `any` for `Find` and `Decode` methods. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L19-R25) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L51-R51) [[3]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L173-R173)

### Test Updates:
* Refactored test cases in `internal/extractor/extractor_test.go` to use `map[string]any` for mock data and function signatures. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L26-R26) [[2]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L45-R45) [[3]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L62-R67) [[4]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L92-R101) [[5]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L114-R114) [[6]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L126-R128) [[7]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L141-R143) [[8]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L156-R159) [[9]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L178-R178) [[10]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L193-R201) [[11]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L216-R216) [[12]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L229-R229) [[13]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L245-R253) [[14]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L268-R268) [[15]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L283-R285) [[16]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L298-R298) [[17]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L320-R321) [[18]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L335-R335) [[19]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L356-R357)

### Loader Updates:
* Updated the `MarshalFunc` and `DynamoLoader` methods in `internal/loader/loader.go` to use `any` for improved clarity and consistency. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL33-R33) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL71-R71) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL207-R207)