### PR TITLE
fix(version): Add missing period in version command description

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -12,7 +12,7 @@ import (
 var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
-	Long:  `Print the version number of mongo2dynamo`,
+	Long:  `Print the version number of mongo2dynamo.`,
 	Run:   runVersion,
 }
 


### PR DESCRIPTION
This pull request includes a minor change to the `cmd/version/version.go` file. A period was added to the end of the `Long` description in the `VersionCmd` command to improve grammatical correctness.