### PR TITLE
chore: Remove dist/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 bin/
 vendor/
 .vscode/
-dist/
 coverage.out


### PR DESCRIPTION
This pull request removes the `dist/` directory from `.gitignore` as it is no longer used in the project. The `dist/` folder was previously being ignored but is not part of the current project structure, so removing it from `.gitignore` helps keep the ignore rules clean and relevant to the actual project needs.