### PR TITLE
refactor: Replace primitive.M with bson.M throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ flowchart LR
 - Utilizes a **dynamic worker pool** starting with CPU core count, scaling up to 2x CPU cores based on workload.
 - **Real-time scaling**: Workers auto-adjust every 500ms when pending jobs exceed 2x current worker count.
 - **Memory optimization**: Pre-calculates field counts to allocate maps with optimal capacity, reducing garbage collection overhead.
-- **Field processing**: Converts `_id` to `id` with intelligent type handling (ObjectID → hex, primitive.M → JSON), removes `__v` and `_class` fields.
+- **Field processing**: Converts `_id` to `id` with intelligent type handling (ObjectID → hex, bson.M → JSON), removes `__v` and `_class` fields.
 - Implements panic recovery and comprehensive error reporting for worker failures.
 
 ### 3. Loading

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"mongo2dynamo/internal/common"
@@ -75,7 +76,7 @@ func convertID(id any) any {
 	switch v := id.(type) {
 	case primitive.ObjectID:
 		return v.Hex()
-	case primitive.M:
+	case bson.M:
 		jsonBytes, err := json.Marshal(v)
 		if err != nil {
 			return fmt.Sprintf("%v", v)

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -123,17 +124,17 @@ func TestConvertID(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "primitive.M conversion",
-			input: primitive.M{
+			name: "bson.M conversion",
+			input: bson.M{
 				"user": "some user",
 				"ts":   "2023-01-01T00:00:00Z",
 			},
 			expected: `{"ts":"2023-01-01T00:00:00Z","user":"some user"}`,
 		},
 		{
-			name: "nested primitive.M conversion",
-			input: primitive.M{
-				"user": primitive.M{
+			name: "nested bson.M conversion",
+			input: bson.M{
+				"user": bson.M{
 					"id":   "123",
 					"name": "John Doe",
 				},
@@ -165,16 +166,16 @@ func TestConvertID(t *testing.T) {
 				if resultStr != expectedHex {
 					t.Errorf("ObjectID conversion: expected %s, got %s", expectedHex, resultStr)
 				}
-			case "primitive.M conversion", "nested primitive.M conversion":
+			case "bson.M conversion", "nested bson.M conversion":
 				// For JSON objects, we need to parse and compare the structure.
 				resultStr, ok := result.(string)
 				if !ok {
-					t.Errorf("primitive.M conversion: expected string result, got %T", result)
+					t.Errorf("bson.M conversion: expected string result, got %T", result)
 					return
 				}
 				expectedStr, ok := tt.expected.(string)
 				if !ok {
-					t.Errorf("primitive.M conversion: expected string in test data, got %T", tt.expected)
+					t.Errorf("bson.M conversion: expected string in test data, got %T", tt.expected)
 					return
 				}
 				var resultMap, expectedMap map[string]any

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -76,7 +76,7 @@ func setupMongoDB(t *testing.T, mongoHost, mongoPort string) *mongo.Client {
 
 	// Insert test data.
 	collection := mongoClient.Database("testdb").Collection("testcol")
-	_, err = collection.InsertOne(ctx, primitive.M{
+	_, err = collection.InsertOne(ctx, bson.M{
 		"_id":    "mongoid-001",
 		"__v":    7,
 		"_class": "com.example.MyEntity",


### PR DESCRIPTION
This pull request refactors the MongoDB-related code to replace the usage of `primitive.M` and `primitive.A` with `bson.M` and `bson.A` respectively. The changes aim to standardize the BSON document type usage across the codebase, improve readability, and align with MongoDB's recommended practices.

### Refactoring MongoDB BSON document types:
* [`internal/extractor/extractor.go`](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L8): Replaced `primitive.M` with `bson.M` in multiple locations, including filter and projection parsing, function parameters, and return types. Updated the `parseMongoJSON` function to use `bson.M`. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L8) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L35-R35) [[3]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L65-R64) [[4]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L84-R83) [[5]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L93-R92) [[6]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L119-R125) [[7]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L153-R152)
* [`internal/transformer/transformer.go`](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R9): Updated the `convertID` function to handle `bson.M` instead of `primitive.M`. [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R9) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L78-R79)

### Updates to unit tests:
* [`internal/extractor/extractor_test.go`](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063R13): Replaced `primitive.M` and `primitive.A` with `bson.M` and `bson.A` in test cases to reflect the refactored code. This change was applied to tests for extractor functionality, filter and projection handling, and JSON parsing. [[1]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063R13) [[2]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L98-R99) [[3]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L125-R126) [[4]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L155-R156) [[5]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L177-R178) [[6]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L199-R200) [[7]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L226-R227) [[8]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L252-R253) [[9]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L279-R280) [[10]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L309-R319) [[11]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L345-R355) [[12]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L379-R380) [[13]](diffhunk://#diff-5a0e11af19c0af617fdd56657f46499529fc2ac1005d7c5afcaa7546e4e56063L407-R408)
* [`internal/transformer/transformer_test.go`](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005R13): Updated test cases for `convertID` to use `bson.M` instead of `primitive.M`. Adjusted assertions and test descriptions accordingly. [[1]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005R13) [[2]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L126-R137) [[3]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L168-R178)

### Integration tests:
* [`test/integration/integration_test.go`](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL19-R19): Updated the test setup to use `bson.M` instead of `primitive.M` when inserting test data into MongoDB. [[1]](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL19-R19) [[2]](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL79-R79)