### PR TITLE
chore(deps): Upgrade go version to 1.24.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mongo2dynamo
 
-go 1.24.4
+go 1.24.5
 
 require github.com/spf13/cobra v1.9.1
 


### PR DESCRIPTION
This pull request updates the Go version used in the `mongo2dynamo` module.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.24.4` to `1.24.5` to ensure compatibility with the latest features and bug fixes.