### PR TITLE
refactor(config): Centralize flag processing logic

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -38,44 +38,8 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Then override with flag values if they were explicitly set.
-	if cmd.Flags().Changed("mongo-host") {
-		cfg.MongoHost, _ = cmd.Flags().GetString("mongo-host")
-	}
-	if cmd.Flags().Changed("mongo-port") {
-		cfg.MongoPort, _ = cmd.Flags().GetString("mongo-port")
-	}
-	if cmd.Flags().Changed("mongo-user") {
-		cfg.MongoUser, _ = cmd.Flags().GetString("mongo-user")
-	}
-	if cmd.Flags().Changed("mongo-password") {
-		cfg.MongoPassword, _ = cmd.Flags().GetString("mongo-password")
-	}
-	if cmd.Flags().Changed("mongo-db") {
-		cfg.MongoDB, _ = cmd.Flags().GetString("mongo-db")
-	}
-	if cmd.Flags().Changed("mongo-collection") {
-		cfg.MongoCollection, _ = cmd.Flags().GetString("mongo-collection")
-	}
-	if cmd.Flags().Changed("dynamo-endpoint") {
-		cfg.DynamoEndpoint, _ = cmd.Flags().GetString("dynamo-endpoint")
-	}
-	if cmd.Flags().Changed("dynamo-table") {
-		cfg.DynamoTable, _ = cmd.Flags().GetString("dynamo-table")
-	}
-	if cmd.Flags().Changed("aws-region") {
-		cfg.AWSRegion, _ = cmd.Flags().GetString("aws-region")
-	}
-	if cmd.Flags().Changed("auto-approve") {
-		cfg.AutoApprove, _ = cmd.Flags().GetBool("auto-approve")
-	}
-	if cmd.Flags().Changed("max-retries") {
-		cfg.MaxRetries, _ = cmd.Flags().GetInt("max-retries")
-	}
-	if cmd.Flags().Changed("mongo-filter") {
-		cfg.MongoFilter, _ = cmd.Flags().GetString("mongo-filter")
-	}
-	if cmd.Flags().Changed("no-progress") {
-		cfg.NoProgress, _ = cmd.Flags().GetBool("no-progress")
+	if err := cfg.OverrideConfigWithFlags(cmd); err != nil {
+		return fmt.Errorf("failed to override config with flags: %w", err)
 	}
 
 	// Validate configuration after all values are set.

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -37,29 +37,8 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Then override with flag values if they were explicitly set.
-	if cmd.Flags().Changed("mongo-host") {
-		cfg.MongoHost, _ = cmd.Flags().GetString("mongo-host")
-	}
-	if cmd.Flags().Changed("mongo-port") {
-		cfg.MongoPort, _ = cmd.Flags().GetString("mongo-port")
-	}
-	if cmd.Flags().Changed("mongo-user") {
-		cfg.MongoUser, _ = cmd.Flags().GetString("mongo-user")
-	}
-	if cmd.Flags().Changed("mongo-password") {
-		cfg.MongoPassword, _ = cmd.Flags().GetString("mongo-password")
-	}
-	if cmd.Flags().Changed("mongo-db") {
-		cfg.MongoDB, _ = cmd.Flags().GetString("mongo-db")
-	}
-	if cmd.Flags().Changed("mongo-collection") {
-		cfg.MongoCollection, _ = cmd.Flags().GetString("mongo-collection")
-	}
-	if cmd.Flags().Changed("mongo-filter") {
-		cfg.MongoFilter, _ = cmd.Flags().GetString("mongo-filter")
-	}
-	if cmd.Flags().Changed("no-progress") {
-		cfg.NoProgress, _ = cmd.Flags().GetBool("no-progress")
+	if err := cfg.OverrideConfigWithFlags(cmd); err != nil {
+		return fmt.Errorf("failed to override config with flags: %w", err)
 	}
 
 	// Set dry run mode.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"mongo2dynamo/internal/common"
@@ -184,6 +185,98 @@ func isValidKeyType(keyType string) bool {
 	default:
 		return false
 	}
+}
+
+func overrideStringFlag(cmd *cobra.Command, flagName string, target *string) error {
+	if cmd.Flags().Changed(flagName) {
+		val, err := cmd.Flags().GetString(flagName)
+		if err != nil {
+			return fmt.Errorf("failed to get string flag %s: %w", flagName, err)
+		}
+		*target = val
+	}
+	return nil
+}
+
+func overrideIntFlag(cmd *cobra.Command, flagName string, target *int) error {
+	if cmd.Flags().Changed(flagName) {
+		val, err := cmd.Flags().GetInt(flagName)
+		if err != nil {
+			return fmt.Errorf("failed to get int flag %s: %w", flagName, err)
+		}
+		*target = val
+	}
+	return nil
+}
+
+func overrideBoolFlag(cmd *cobra.Command, flagName string, target *bool) error {
+	if cmd.Flags().Changed(flagName) {
+		val, err := cmd.Flags().GetBool(flagName)
+		if err != nil {
+			return fmt.Errorf("failed to get bool flag %s: %w", flagName, err)
+		}
+		*target = val
+	}
+	return nil
+}
+
+// OverrideConfigWithFlags overrides the config with the values from the flags.
+func (c *Config) OverrideConfigWithFlags(cmd *cobra.Command) error {
+	if err := overrideStringFlag(cmd, "mongo-host", &c.MongoHost); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "mongo-port", &c.MongoPort); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "mongo-user", &c.MongoUser); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "mongo-password", &c.MongoPassword); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "mongo-db", &c.MongoDB); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "mongo-collection", &c.MongoCollection); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "mongo-filter", &c.MongoFilter); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "mongo-projection", &c.MongoProjection); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "dynamo-endpoint", &c.DynamoEndpoint); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "dynamo-table", &c.DynamoTable); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "dynamo-partition-key", &c.DynamoPartitionKey); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "dynamo-partition-key-type", &c.DynamoPartitionKeyType); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "dynamo-sort-key", &c.DynamoSortKey); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "dynamo-sort-key-type", &c.DynamoSortKeyType); err != nil {
+		return err
+	}
+	if err := overrideStringFlag(cmd, "aws-region", &c.AWSRegion); err != nil {
+		return err
+	}
+	if err := overrideIntFlag(cmd, "max-retries", &c.MaxRetries); err != nil {
+		return err
+	}
+	if err := overrideBoolFlag(cmd, "auto-approve", &c.AutoApprove); err != nil {
+		return err
+	}
+	if err := overrideBoolFlag(cmd, "no-progress", &c.NoProgress); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *Config) GetMongoHost() string {


### PR DESCRIPTION
This pull request refactors the configuration override logic for command-line flags in the `mongo2dynamo` project to improve code maintainability and testability. The key changes include consolidating flag override logic into reusable helper functions, introducing a new `OverrideConfigWithFlags` method in the `Config` struct, and adding comprehensive unit tests to validate the new functionality.

### Refactoring and Code Consolidation:
- **Introduced reusable helper functions**: Added `overrideStringFlag`, `overrideIntFlag`, and `overrideBoolFlag` in `internal/config/config.go` to encapsulate the logic for overriding configuration values based on command-line flags.
- **Added `OverrideConfigWithFlags` method**: Created a method in the `Config` struct to centralize all flag-based configuration overrides, replacing repetitive flag-checking code in multiple commands.

### Simplification of Command Logic:
- **Refactored `runApply` and `runPlan` functions**: Replaced repetitive flag-checking code with a call to the new `OverrideConfigWithFlags` method in `cmd/apply/apply.go` and `cmd/plan/plan.go`. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL41-R41) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L40-R40)

### Testing Enhancements:
- **Added unit tests for `OverrideConfigWithFlags`**: Included a comprehensive set of test cases in `internal/config/config_test.go` to validate the behavior of the new method under various scenarios, including string, int, and bool flag overrides.

### Dependency Updates:
- **Imported `cobra` in `config.go`**: Added the `cobra` package import to support the new flag override logic.
- **Updated test dependencies**: Added `cobra` and `testify` imports in `config_test.go` to facilitate testing of the new functionality.