### PR TITLE
fix(cmd): Add missing flag handlers

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -56,23 +56,38 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if cmd.Flags().Changed("mongo-collection") {
 		cfg.MongoCollection, _ = cmd.Flags().GetString("mongo-collection")
 	}
+	if cmd.Flags().Changed("mongo-filter") {
+		cfg.MongoFilter, _ = cmd.Flags().GetString("mongo-filter")
+	}
+	if cmd.Flags().Changed("mongo-projection") {
+		cfg.MongoProjection, _ = cmd.Flags().GetString("mongo-projection")
+	}
 	if cmd.Flags().Changed("dynamo-endpoint") {
 		cfg.DynamoEndpoint, _ = cmd.Flags().GetString("dynamo-endpoint")
 	}
 	if cmd.Flags().Changed("dynamo-table") {
 		cfg.DynamoTable, _ = cmd.Flags().GetString("dynamo-table")
 	}
+	if cmd.Flags().Changed("dynamo-partition-key") {
+		cfg.DynamoPartitionKey, _ = cmd.Flags().GetString("dynamo-partition-key")
+	}
+	if cmd.Flags().Changed("dynamo-partition-key-type") {
+		cfg.DynamoPartitionKeyType, _ = cmd.Flags().GetString("dynamo-partition-key-type")
+	}
+	if cmd.Flags().Changed("dynamo-sort-key") {
+		cfg.DynamoSortKey, _ = cmd.Flags().GetString("dynamo-sort-key")
+	}
+	if cmd.Flags().Changed("dynamo-sort-key-type") {
+		cfg.DynamoSortKeyType, _ = cmd.Flags().GetString("dynamo-sort-key-type")
+	}
 	if cmd.Flags().Changed("aws-region") {
 		cfg.AWSRegion, _ = cmd.Flags().GetString("aws-region")
-	}
-	if cmd.Flags().Changed("auto-approve") {
-		cfg.AutoApprove, _ = cmd.Flags().GetBool("auto-approve")
 	}
 	if cmd.Flags().Changed("max-retries") {
 		cfg.MaxRetries, _ = cmd.Flags().GetInt("max-retries")
 	}
-	if cmd.Flags().Changed("mongo-filter") {
-		cfg.MongoFilter, _ = cmd.Flags().GetString("mongo-filter")
+	if cmd.Flags().Changed("auto-approve") {
+		cfg.AutoApprove, _ = cmd.Flags().GetBool("auto-approve")
 	}
 	if cmd.Flags().Changed("no-progress") {
 		cfg.NoProgress, _ = cmd.Flags().GetBool("no-progress")

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -58,6 +58,9 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	if cmd.Flags().Changed("mongo-filter") {
 		cfg.MongoFilter, _ = cmd.Flags().GetString("mongo-filter")
 	}
+	if cmd.Flags().Changed("mongo-projection") {
+		cfg.MongoProjection, _ = cmd.Flags().GetString("mongo-projection")
+	}
 	if cmd.Flags().Changed("no-progress") {
 		cfg.NoProgress, _ = cmd.Flags().GetBool("no-progress")
 	}


### PR DESCRIPTION
This pull request introduces additional configuration options for MongoDB and DynamoDB in the `apply` and `plan` commands, enhancing flexibility for database operations. The most important changes include adding new flags for MongoDB projection and DynamoDB key configurations, along with some minor rearrangements for consistency.

### MongoDB Enhancements:
* Added support for the `mongo-projection` flag, allowing users to specify which fields to include or exclude in MongoDB queries. (`cmd/apply/apply.go`, `cmd/plan/plan.go`) [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR59-R90) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R61-R63)

### DynamoDB Enhancements:
* Introduced new flags for configuring DynamoDB keys:
  - `dynamo-partition-key` and `dynamo-partition-key-type` for specifying the partition key and its type.
  - `dynamo-sort-key` and `dynamo-sort-key-type` for specifying the sort key and its type. (`cmd/apply/apply.go`)

### Code Consistency:
* Rearranged the position of the `auto-approve` flag handling in the `apply` command for better logical grouping. (`cmd/apply/apply.go`)