### PR TITLE
refactor: Rename tracker variable to progressTracker for clarity

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -141,12 +141,12 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	// Create progress tracker (only if progress is enabled).
-	var tracker *progress.Tracker
+	// Create progressTracker (only if progress is enabled).
+	var progressTracker *progress.Tracker
 	if !cfg.GetNoProgress() {
-		tracker = progress.NewProgressTracker(total, 1*time.Second)
-		tracker.Start(cmd.Context())
-		defer tracker.Stop()
+		progressTracker = progress.NewProgressTracker(total, 1*time.Second)
+		progressTracker.Start(cmd.Context())
+		defer progressTracker.Stop()
 	}
 
 	// Pipeline channels.
@@ -171,8 +171,8 @@ func runApply(cmd *cobra.Command, _ []string) error {
 			}
 			processed := int64(len(transformed))
 			atomic.AddInt64(&migratedCount, processed)
-			if tracker != nil {
-				tracker.UpdateProgress(processed)
+			if progressTracker != nil {
+				progressTracker.UpdateProgress(processed)
 			}
 		}
 	}()
@@ -221,8 +221,8 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	wg.Wait()
 
 	// Clear progress tracker if it was enabled.
-	if tracker != nil {
-		tracker.ClearProgress()
+	if progressTracker != nil {
+		progressTracker.ClearProgress()
 	}
 
 	// Check for errors.

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -96,12 +96,12 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	// Create progress tracker for plan mode (only if progress is enabled).
-	var tracker *progress.Tracker
+	// Create progressTracker for plan mode (only if progress is enabled).
+	var progressTracker *progress.Tracker
 	if !cfg.GetNoProgress() {
-		tracker = progress.NewProgressTracker(total, 1*time.Second)
-		tracker.Start(cmd.Context())
-		defer tracker.Stop()
+		progressTracker = progress.NewProgressTracker(total, 1*time.Second)
+		progressTracker.Start(cmd.Context())
+		defer progressTracker.Stop()
 	}
 
 	// Pipeline channels.
@@ -133,8 +133,8 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 			}
 			processed := int64(len(transformed))
 			atomic.AddInt64(&totalCount, processed)
-			if tracker != nil {
-				tracker.UpdateProgress(processed)
+			if progressTracker != nil {
+				progressTracker.UpdateProgress(processed)
 			}
 		}
 	}()
@@ -155,8 +155,8 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 	wg.Wait()
 
 	// Clear progress tracker if it was enabled.
-	if tracker != nil {
-		tracker.ClearProgress()
+	if progressTracker != nil {
+		progressTracker.ClearProgress()
 	}
 
 	// Check for errors.

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -10,31 +10,31 @@ import (
 
 func TestProgressTracker(t *testing.T) {
 	t.Run("NewProgressTracker", func(t *testing.T) {
-		tracker := NewProgressTracker(1000, 1*time.Second)
+		progressTracker := NewProgressTracker(1000, 1*time.Second)
 
-		assert.NotNil(t, tracker)
-		assert.Equal(t, int64(1000), tracker.totalItems)
-		assert.Equal(t, 1*time.Second, tracker.updateInterval)
+		assert.NotNil(t, progressTracker)
+		assert.Equal(t, int64(1000), progressTracker.totalItems)
+		assert.Equal(t, 1*time.Second, progressTracker.updateInterval)
 	})
 
 	t.Run("UpdateProgress", func(t *testing.T) {
-		tracker := NewProgressTracker(100, 1*time.Second)
+		progressTracker := NewProgressTracker(100, 1*time.Second)
 
-		tracker.UpdateProgress(10)
-		tracker.UpdateProgress(20)
+		progressTracker.UpdateProgress(10)
+		progressTracker.UpdateProgress(20)
 
-		status := tracker.GetProgressStatus()
+		status := progressTracker.GetProgressStatus()
 		assert.Equal(t, int64(30), status.Processed)
 		assert.Equal(t, float64(30), status.Percentage)
 	})
 
 	t.Run("GetProgress", func(t *testing.T) {
-		tracker := NewProgressTracker(100, 1*time.Second)
-		tracker.startTime = time.Now().Add(-10 * time.Second) // Simulate 10 seconds elapsed.
+		progressTracker := NewProgressTracker(100, 1*time.Second)
+		progressTracker.startTime = time.Now().Add(-10 * time.Second) // Simulate 10 seconds elapsed.
 
-		tracker.UpdateProgress(50)
+		progressTracker.UpdateProgress(50)
 
-		status := tracker.GetProgressStatus()
+		status := progressTracker.GetProgressStatus()
 		assert.Equal(t, int64(50), status.Processed)
 		assert.Equal(t, int64(100), status.Total)
 		assert.Equal(t, float64(50), status.Percentage)
@@ -42,13 +42,13 @@ func TestProgressTracker(t *testing.T) {
 	})
 
 	t.Run("StartAndStop", func(t *testing.T) {
-		tracker := NewProgressTracker(100, 100*time.Millisecond)
+		progressTracker := NewProgressTracker(100, 100*time.Millisecond)
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 
-		tracker.Start(ctx)
+		progressTracker.Start(ctx)
 		time.Sleep(50 * time.Millisecond)
-		tracker.Stop()
+		progressTracker.Stop()
 
 		// Should not panic.
 		assert.True(t, true)


### PR DESCRIPTION
This pull request standardizes the naming of the `progressTracker` variable across the codebase for better readability and consistency. The changes affect multiple files, including `apply.go`, `plan.go`, and `progress_test.go`.

### Updates to progress tracker variable naming:

* **`cmd/apply/apply.go`:** Renamed `tracker` to `progressTracker` in the `runApply` function. Updated all references accordingly, including initialization, progress updates, and cleanup. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL144-R149) [[2]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL174-R175) [[3]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL224-R225)

* **`cmd/plan/plan.go`:** Renamed `tracker` to `progressTracker` in the `runPlan` function. Adjusted all related references, including progress initialization, updates, and clearing. [[1]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L99-R104) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L136-R137) [[3]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L158-R159)

* **`internal/progress/progress_test.go`:** Refactored test cases to use `progressTracker` instead of `tracker`, ensuring consistency in variable naming across test functions.