### PR TITLE
refactor: Replace magic numbers with named constants

### DIFF
--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -13,6 +13,11 @@ import (
 	"mongo2dynamo/internal/pool"
 )
 
+const (
+	DefaultMongoBatchSize = 1000
+	DefaultChunkSize      = 2000
+)
+
 // Collection defines the interface for MongoDB collection operations needed by Extractor.
 type Collection interface {
 	Find(ctx context.Context, filter any, opts ...*options.FindOptions) (Cursor, error)
@@ -64,10 +69,10 @@ func (w *mongoCollectionWrapper) Find(ctx context.Context, filter any, opts ...*
 func newMongoExtractor(collection Collection, filter bson.M) *MongoExtractor {
 	return &MongoExtractor{
 		collection: collection,
-		batchSize:  1000,
-		chunkSize:  2000,
+		batchSize:  DefaultMongoBatchSize,
+		chunkSize:  DefaultChunkSize,
 		filter:     filter,
-		chunkPool:  pool.NewChunkPool(2000),
+		chunkPool:  pool.NewChunkPool(DefaultChunkSize),
 	}
 }
 

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -10,6 +10,10 @@ import (
 	"mongo2dynamo/internal/common"
 )
 
+const (
+	DefaultUpdateInterval = 1 * time.Second
+)
+
 // Status contains information about the migration progress.
 type Status struct {
 	Processed  int64
@@ -40,7 +44,7 @@ type Tracker struct {
 // NewProgressTracker creates a new progress tracker.
 func NewProgressTracker(totalItems int64, updateInterval time.Duration) *Tracker {
 	if updateInterval <= 0 {
-		updateInterval = 1 * time.Second
+		updateInterval = DefaultUpdateInterval
 	}
 
 	return &Tracker{

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -6,6 +6,10 @@ import (
 	"time"
 )
 
+const (
+	DefaultMaxRetries = 5
+)
+
 // RetryableFunc defines a function that can be retried and returns only an error.
 type RetryableFunc func() error
 
@@ -18,7 +22,7 @@ type Config struct {
 // NewConfig creates a new retry configuration with default values.
 func NewConfig() *Config {
 	return &Config{
-		MaxRetries:    5,
+		MaxRetries:    DefaultMaxRetries,
 		BackoffConfig: NewBackoffConfig(),
 	}
 }

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -12,6 +12,16 @@ import (
 	"mongo2dynamo/internal/worker"
 )
 
+const (
+	DefaultMinWorkers    = 2
+	DefaultScaleInterval = 500 * time.Millisecond
+)
+
+var (
+	DefaultMaxWorkers = runtime.NumCPU() * 2
+	DefaultQueueSize  = DefaultMaxWorkers * 2
+)
+
 // DocTransformer transforms MongoDB documents.
 type DocTransformer struct{}
 
@@ -54,10 +64,7 @@ func (t *DocTransformer) Transform(
 	}
 
 	// Configure and run the dynamic worker pool.
-	minWorkers := 2
-	maxWorkers := runtime.NumCPU() * 2
-	queueSize := maxWorkers * 2
-	pool := worker.NewDynamicWorkerPool(transformFunc, minWorkers, maxWorkers, queueSize, 500*time.Millisecond)
+	pool := worker.NewDynamicWorkerPool(transformFunc, DefaultMinWorkers, DefaultMaxWorkers, DefaultQueueSize, DefaultScaleInterval)
 	defer pool.Stop()
 
 	pool.Start(ctx)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	DefaultScaleInterval       = 500 * time.Millisecond
-	DefaultScaleUpThreshold    = 0.8
-	DefaultScaleDownThreshold  = 0.3
+	DefaultScaleInterval      = 500 * time.Millisecond
+	DefaultScaleUpThreshold   = 0.8
+	DefaultScaleDownThreshold = 0.3
+
 	DefaultMinWorkers          = 1
 	ScaleDownChannelBufferSize = 1
 )


### PR DESCRIPTION
This pull request refactors several modules to centralize and standardize default configuration values by introducing named constants. This improves maintainability and consistency across the codebase, making it easier to update default settings and reducing the risk of hard-coded values.

### Default value centralization

* Introduced named constants for default batch sizes, chunk sizes, worker pool parameters, update intervals, and retry counts in their respective files (`extractor.go`, `loader.go`, `progress.go`, `retry.go`, `transformer.go`). [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0R16-R20) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL21-R21) [[3]](diffhunk://#diff-66d4349586a1dea4bd4de639d9a4a0439f4e011ca6b4f8667b1852baef6cf7c6R13-R16) [[4]](diffhunk://#diff-4a2ee6d6ad73601b788841263dba9c8e914d232d23cce65dac6bea897be8314fR9-R12) [[5]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R15-R24)

### Refactoring to use centralized defaults

* Updated constructors and initialization logic to use the newly defined constants instead of hard-coded values, including in `newMongoExtractor`, `DynamoLoader.Load`, `NewProgressTracker`, `NewConfig`, and dynamic worker pool creation. [[1]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L67-R75) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL245-R245) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL261-R267) [[4]](diffhunk://#diff-66d4349586a1dea4bd4de639d9a4a0439f4e011ca6b4f8667b1852baef6cf7c6L43-R47) [[5]](diffhunk://#diff-4a2ee6d6ad73601b788841263dba9c8e914d232d23cce65dac6bea897be8314fL21-R25) [[6]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L57-R67)

### Worker pool configuration improvements

* Refactored worker pool setup in `transformer.go` to use centralized constants for minimum/maximum workers, queue size, and scaling interval.

### Minor consistency update

* Added a newline for grouping in the worker constants block for readability.