### PR TITLE
refactor: Reorganize constant declarations for better readability

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -18,11 +18,10 @@ import (
 )
 
 const (
-	DefaultDynamoBatchSize = 25
-	DefaultLoaderWorkers   = 10
-
 	MaxWaitTimeForTableActive   = 30 * time.Second
 	CheckIntervalForTableActive = 2 * time.Second
+	DefaultDynamoBatchSize      = 25
+	DefaultLoaderWorkers        = 10
 )
 
 // DBClient defines the interface for DynamoDB operations used by Loader.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -10,12 +10,11 @@ import (
 )
 
 const (
-	DefaultScaleInterval      = 500 * time.Millisecond
-	DefaultScaleUpThreshold   = 0.8
-	DefaultScaleDownThreshold = 0.3
-
 	DefaultMinWorkers          = 1
 	ScaleDownChannelBufferSize = 1
+	DefaultScaleInterval       = 500 * time.Millisecond
+	DefaultScaleUpThreshold    = 0.8
+	DefaultScaleDownThreshold  = 0.3
 )
 
 var (


### PR DESCRIPTION
This pull request makes minor adjustments to the ordering of constant declarations in two files to improve code organization and readability.

* Code organization:
  * In `internal/loader/loader.go`, the ordering of `DefaultDynamoBatchSize` and `DefaultLoaderWorkers` constants is changed to appear after other time-related constants.
  * In `internal/worker/worker.go`, the ordering of `DefaultMinWorkers` and `ScaleDownChannelBufferSize` constants is changed to appear before other scaling-related constants.