### PR TITLE
refactor(config): Replace getter methods with direct field access

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -143,7 +143,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	// Create progressTracker (only if progress is enabled).
 	var progressTracker *progress.Tracker
-	if !cfg.GetNoProgress() {
+	if !cfg.NoProgress {
 		progressTracker = progress.NewProgressTracker(total, 1*time.Second)
 		progressTracker.Start(cmd.Context())
 		defer progressTracker.Stop()

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -30,6 +30,7 @@ This command will display what would be migrated without making any changes.`,
 func runPlan(cmd *cobra.Command, _ []string) error {
 	// Create config.
 	cfg := &config.Config{}
+	cfg.SetDryRun(true)
 
 	// Load configuration from environment variables, config file, and defaults first.
 	if err := cfg.Load(); err != nil {
@@ -65,9 +66,6 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 		cfg.NoProgress, _ = cmd.Flags().GetBool("no-progress")
 	}
 
-	// Set dry run mode.
-	cfg.SetDryRun(true)
-
 	// Validate configuration after all values are set.
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("configuration validation failed: %w", err)
@@ -98,7 +96,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 
 	// Create progressTracker for plan mode (only if progress is enabled).
 	var progressTracker *progress.Tracker
-	if !cfg.GetNoProgress() {
+	if !cfg.NoProgress {
 		progressTracker = progress.NewProgressTracker(total, 1*time.Second)
 		progressTracker.Start(cmd.Context())
 		defer progressTracker.Stop()

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -26,27 +26,3 @@ type Loader interface {
 	// Load saves the provided data to the destination.
 	Load(ctx context.Context, data []map[string]any) error
 }
-
-// ConfigProvider is the interface for providing configuration settings.
-type ConfigProvider interface {
-	GetMongoHost() string
-	GetMongoPort() string
-	GetMongoUser() string
-	GetMongoPassword() string
-	GetMongoDB() string
-	GetMongoCollection() string
-	GetMongoFilter() string
-	GetMongoProjection() string
-	GetMongoURI() string
-	GetDynamoEndpoint() string
-	GetDynamoTable() string
-	GetDynamoPartitionKey() string
-	GetDynamoPartitionKeyType() string
-	GetDynamoSortKey() string
-	GetDynamoSortKeyType() string
-	GetAWSRegion() string
-	GetMaxRetries() int
-	GetAutoApprove() bool
-	GetDryRun() bool
-	GetNoProgress() bool
-}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,10 @@ type Config struct {
 
 	// Application configuration.
 	AutoApprove bool `mapstructure:"auto_approve"`
-	DryRun      bool `mapstructure:"dry_run"`
 	NoProgress  bool `mapstructure:"no_progress"`
+
+	// Dry run mode.
+	dryRun bool
 }
 
 // Load loads configuration from environment variables and config file.
@@ -109,7 +111,7 @@ func (c *Config) Validate() error {
 	}
 
 	// If DynamoTable is not set and not in DryRun mode, use the collection name as the DynamoDB table name.
-	if !c.DryRun && c.DynamoTable == "" {
+	if !c.IsDryRun() && c.DynamoTable == "" {
 		// If AutoApprove is false, prompt the user for confirmation before proceeding.
 		if !c.AutoApprove && !common.Confirm("Use collection name as DynamoDB table name? (y/N) ") {
 			return fmt.Errorf("required field 'dynamo_table' not set: user declined to use collection name: %w", context.Canceled)
@@ -130,90 +132,21 @@ func isValidKeyType(keyType string) bool {
 	}
 }
 
-func (c *Config) GetMongoHost() string {
-	return c.MongoHost
+// SetDryRun sets the dry run mode.
+func (c *Config) SetDryRun(dryRun bool) {
+	c.dryRun = dryRun
 }
 
-func (c *Config) GetMongoPort() string {
-	return c.MongoPort
+// IsDryRun returns whether dry run mode is enabled.
+func (c *Config) IsDryRun() bool {
+	return c.dryRun
 }
 
-func (c *Config) GetMongoUser() string {
-	return c.MongoUser
-}
-
-func (c *Config) GetMongoPassword() string {
-	return c.MongoPassword
-}
-
-func (c *Config) GetMongoDB() string {
-	return c.MongoDB
-}
-
-func (c *Config) GetMongoCollection() string {
-	return c.MongoCollection
-}
-
-func (c *Config) GetMongoFilter() string {
-	return c.MongoFilter
-}
-
-func (c *Config) GetMongoProjection() string {
-	return c.MongoProjection
-}
-
-func (c *Config) GetMongoURI() string {
+// BuildMongoURI builds the MongoDB connection URI.
+func (c *Config) BuildMongoURI() string {
 	if c.MongoUser != "" && c.MongoPassword != "" {
 		return fmt.Sprintf("mongodb://%s:%s@%s:%s",
 			c.MongoUser, c.MongoPassword, c.MongoHost, c.MongoPort)
 	}
 	return fmt.Sprintf("mongodb://%s:%s", c.MongoHost, c.MongoPort)
-}
-
-func (c *Config) GetDynamoEndpoint() string {
-	return c.DynamoEndpoint
-}
-
-func (c *Config) GetDynamoTable() string {
-	return c.DynamoTable
-}
-
-func (c *Config) GetDynamoPartitionKey() string {
-	return c.DynamoPartitionKey
-}
-
-func (c *Config) GetDynamoPartitionKeyType() string {
-	return c.DynamoPartitionKeyType
-}
-
-func (c *Config) GetDynamoSortKey() string {
-	return c.DynamoSortKey
-}
-
-func (c *Config) GetDynamoSortKeyType() string {
-	return c.DynamoSortKeyType
-}
-
-func (c *Config) GetAWSRegion() string {
-	return c.AWSRegion
-}
-
-func (c *Config) GetMaxRetries() int {
-	return c.MaxRetries
-}
-
-func (c *Config) GetAutoApprove() bool {
-	return c.AutoApprove
-}
-
-func (c *Config) GetDryRun() bool {
-	return c.DryRun
-}
-
-func (c *Config) GetNoProgress() bool {
-	return c.NoProgress
-}
-
-func (c *Config) SetDryRun(dryRun bool) {
-	c.DryRun = dryRun
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,27 +257,33 @@ func TestConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "missing dynamo_table but dry run",
-			config: &Config{
-				MongoDB:                "testdb",
-				MongoCollection:        "testcollection",
-				DryRun:                 true,
-				DynamoPartitionKey:     "id",
-				DynamoPartitionKeyType: "S",
-				MaxRetries:             defaultMaxRetries,
-			},
+			config: func() *Config {
+				cfg := &Config{
+					MongoDB:                "testdb",
+					MongoCollection:        "testcollection",
+					DynamoPartitionKey:     "id",
+					DynamoPartitionKeyType: "S",
+					MaxRetries:             defaultMaxRetries,
+				}
+				cfg.SetDryRun(true)
+				return cfg
+			}(),
 			wantErr: false,
 		},
 		{
 			name: "missing dynamo_table with auto-approve should set DynamoTable to collection name",
-			config: &Config{
-				MongoDB:                "testdb",
-				MongoCollection:        "testcollection",
-				DryRun:                 false,
-				AutoApprove:            true,
-				DynamoPartitionKey:     "id",
-				DynamoPartitionKeyType: "S",
-				MaxRetries:             defaultMaxRetries,
-			},
+			config: func() *Config {
+				cfg := &Config{
+					MongoDB:                "testdb",
+					MongoCollection:        "testcollection",
+					AutoApprove:            true,
+					DynamoPartitionKey:     "id",
+					DynamoPartitionKeyType: "S",
+					MaxRetries:             defaultMaxRetries,
+				}
+				cfg.SetDryRun(false)
+				return cfg
+			}(),
 			wantErr: false,
 		},
 		{
@@ -339,7 +345,7 @@ func TestConfig_Validate(t *testing.T) {
 
 			// Check if DynamoTable is automatically set to MongoCollection when empty.
 			// Note: In dry run mode, DynamoTable is not set automatically.
-			if !tt.config.DryRun && tt.config.MongoCollection != "" && tt.config.DynamoTable == "" {
+			if !tt.config.IsDryRun() && tt.config.MongoCollection != "" && tt.config.DynamoTable == "" {
 				// This should not happen after Validate() is called.
 				t.Errorf("DynamoTable should be set to MongoCollection '%s' when empty, but it's still empty", tt.config.MongoCollection)
 			}
@@ -347,7 +353,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestConfig_GetMongoURI(t *testing.T) {
+func TestConfig_BuildMongoURI(t *testing.T) {
 	tests := []struct {
 		name     string
 		config   *Config
@@ -375,9 +381,9 @@ func TestConfig_GetMongoURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.config.GetMongoURI()
+			result := tt.config.BuildMongoURI()
 			if result != tt.expected {
-				t.Errorf("GetMongoURI() = %v, want %v", result, tt.expected)
+				t.Errorf("BuildMongoURI() = %v, want %v", result, tt.expected)
 			}
 		})
 	}

--- a/internal/dynamo/dynamo.go
+++ b/internal/dynamo/dynamo.go
@@ -9,13 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 
 	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/config"
 )
 
 // Connect establishes a connection to DynamoDB.
-func Connect(ctx context.Context, cfg common.ConfigProvider) (*dynamodb.Client, error) {
+func Connect(ctx context.Context, cfg *config.Config) (*dynamodb.Client, error) {
 	// Load AWS configuration.
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithRegion(cfg.GetAWSRegion()),
+		awsconfig.WithRegion(cfg.AWSRegion),
 	)
 	if err != nil {
 		return nil, &common.DatabaseConnectionError{Database: "DynamoDB", Reason: err.Error(), Err: err}
@@ -23,7 +24,7 @@ func Connect(ctx context.Context, cfg common.ConfigProvider) (*dynamodb.Client, 
 
 	// Create DynamoDB client with custom endpoint.
 	client := dynamodb.NewFromConfig(awsCfg, func(o *dynamodb.Options) {
-		o.BaseEndpoint = aws.String(cfg.GetDynamoEndpoint())
+		o.BaseEndpoint = aws.String(cfg.DynamoEndpoint)
 	})
 
 	// Verify connection with timeout.

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -9,6 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/config"
 	"mongo2dynamo/internal/mongo"
 	"mongo2dynamo/internal/pool"
 )
@@ -77,17 +78,18 @@ func newMongoExtractor(collection Collection, filter bson.M) *MongoExtractor {
 }
 
 // NewMongoExtractor creates a MongoExtractor for MongoDB based on the configuration.
-func NewMongoExtractor(ctx context.Context, cfg common.ConfigProvider) (common.Extractor, error) {
+func NewMongoExtractor(ctx context.Context, cfg *config.Config) (common.Extractor, error) {
 	client, err := mongo.Connect(ctx, cfg)
 	if err != nil {
 		return nil, &common.DatabaseConnectionError{Database: "MongoDB", Reason: err.Error(), Err: err}
 	}
-	collection := client.Database(cfg.GetMongoDB()).Collection(cfg.GetMongoCollection())
+
+	collection := client.Database(cfg.MongoDB).Collection(cfg.MongoCollection)
 
 	// Parse MongoDB filter if provided.
 	var filter bson.M
-	if cfg.GetMongoFilter() != "" {
-		filter, err = parseMongoJSON(cfg.GetMongoFilter())
+	if cfg.MongoFilter != "" {
+		filter, err = parseMongoJSON(cfg.MongoFilter)
 		if err != nil {
 			return nil, err
 		}
@@ -95,8 +97,8 @@ func NewMongoExtractor(ctx context.Context, cfg common.ConfigProvider) (common.E
 
 	// Parse MongoDB projection if provided.
 	var projection bson.M
-	if cfg.GetMongoProjection() != "" {
-		projection, err = parseMongoJSON(cfg.GetMongoProjection())
+	if cfg.MongoProjection != "" {
+		projection, err = parseMongoJSON(cfg.MongoProjection)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/mongo/mongo.go
+++ b/internal/mongo/mongo.go
@@ -9,6 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"mongo2dynamo/internal/common"
+	"mongo2dynamo/internal/config"
 )
 
 const (
@@ -32,14 +33,14 @@ var mongoAuthErrorPatterns = []string{
 }
 
 // Connect establishes a connection to MongoDB.
-func Connect(ctx context.Context, cfg common.ConfigProvider) (*mongo.Client, error) {
-	clientOpts := options.Client().ApplyURI(cfg.GetMongoURI())
+func Connect(ctx context.Context, cfg *config.Config) (*mongo.Client, error) {
+	clientOpts := options.Client().ApplyURI(cfg.BuildMongoURI())
 
 	// Explicitly set authentication credentials if provided.
-	if cfg.GetMongoUser() != "" && cfg.GetMongoPassword() != "" {
+	if cfg.MongoUser != "" && cfg.MongoPassword != "" {
 		clientOpts.SetAuth(options.Credential{
-			Username: cfg.GetMongoUser(),
-			Password: cfg.GetMongoPassword(),
+			Username: cfg.MongoUser,
+			Password: cfg.MongoPassword,
 		})
 	}
 


### PR DESCRIPTION
This pull request refactors the configuration management across the codebase to simplify access to configuration properties and improve maintainability. The main changes include removing the `ConfigProvider` interface and its getter methods, updating all components to use direct struct field access, and introducing new methods for dry run mode and MongoDB URI construction. This results in a cleaner and more consistent approach to configuration handling.

**Configuration Refactoring**

* Removed the `ConfigProvider` interface and all associated getter methods from `internal/common/interfaces.go` and `internal/config/config.go`, switching to direct struct field access for configuration properties throughout the codebase. [[1]](diffhunk://#diff-fb0402d90a50c88994fc12453ed2c3f545627f1ee4d21ea3a20fc27d8bd36dffL29-L52) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL133-L219)
* Updated constructors and functions in `internal/dynamo/dynamo.go`, `internal/extractor/extractor.go`, `internal/loader/loader.go`, and `internal/mongo/mongo.go` to accept and use `*config.Config` directly instead of `ConfigProvider`, and replaced all getter method calls with direct field access. [[1]](diffhunk://#diff-83aabefb38a4bad355bf831c068bc9315140f4369ad8deff2e804d56c50e5756R12-R27) [[2]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0R12) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR16) [[4]](diffhunk://#diff-f04a773a82b8b9b655a189e79a6501d3cd6ec7910e99e36d57e0573594c26759R12)

**New Configuration Methods**

* Added `SetDryRun(bool)` and `IsDryRun() bool` methods to `Config`, replacing the previous `DryRun` field and getter, and updated all usages accordingly. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL39-R42) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL133-L219) [[3]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R33) [[4]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L68-L70) [[5]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L260-R286) [[6]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L342-R356)
* Added `BuildMongoURI()` method to `Config`, replacing the previous `GetMongoURI()` method, and updated all usages and related tests. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL133-L219) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L342-R356) [[3]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L378-R386) [[4]](diffhunk://#diff-f04a773a82b8b9b655a189e79a6501d3cd6ec7910e99e36d57e0573594c26759L35-R43)

**Progress Tracker Logic**

* Updated progress tracker logic in `cmd/apply/apply.go` and `cmd/plan/plan.go` to use the `NoProgress` field directly instead of the getter method. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL146-R146) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L101-R99)

These changes streamline configuration usage, reduce boilerplate, and make the code easier to maintain and extend.