### PR TITLE
refactor: Remove hardcoded metadata field exclusion from transformer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,7 +48,7 @@ func (c *Config) Load() error {
 	viper.SetDefault("mongo_host", "localhost")
 	viper.SetDefault("mongo_port", "27017")
 	viper.SetDefault("mongo_filter", "")
-	viper.SetDefault("mongo_projection", "")
+	viper.SetDefault("mongo_projection", "{\"__v\":0,\"_class\":0}")
 	viper.SetDefault("dynamo_endpoint", "http://localhost:8000")
 	viper.SetDefault("dynamo_partition_key", "_id")
 	viper.SetDefault("dynamo_partition_key_type", "S")

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -13,7 +13,7 @@ func AddMongoFlags(cmd *cobra.Command) {
 	cmd.Flags().String("mongo-db", "", "MongoDB database name.")
 	cmd.Flags().String("mongo-collection", "", "MongoDB collection name.")
 	cmd.Flags().String("mongo-filter", "", "MongoDB query filter (JSON string).")
-	cmd.Flags().String("mongo-projection", "", "MongoDB projection (JSON string). Only the specified fields will be included in the result documents.")
+	cmd.Flags().String("mongo-projection", "{\"__v\":0,\"_class\":0}", "MongoDB projection (JSON string). Default is to exclude common framework metadata fields (__v, _class).")
 }
 
 // AddDynamoFlags adds DynamoDB-related flags to the command.

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -39,7 +39,7 @@ func TestAddMongoFlags(t *testing.T) {
 
 	projectionFlag := cmd.Flags().Lookup("mongo-projection")
 	assert.NotNil(t, projectionFlag, "mongo-projection flag should be registered")
-	assert.Equal(t, "", projectionFlag.DefValue)
+	assert.Equal(t, "{\"__v\":0,\"_class\":0}", projectionFlag.DefValue)
 }
 
 func TestAddDynamoFlags(t *testing.T) {

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -51,13 +51,7 @@ func (t *DocTransformer) Transform(
 
 		newDoc := make(map[string]any, estimatedFields)
 		for k, v := range doc {
-			switch k {
-			case "__v", "_class":
-				// Remove framework metadata fields.
-				continue
-			default:
-				newDoc[k] = convertValue(v)
-			}
+			newDoc[k] = convertValue(v)
 		}
 		return worker.Result[map[string]any]{JobID: job.ID, Value: newDoc}
 	}


### PR DESCRIPTION
This pull request updates the default handling of MongoDB framework metadata fields (`__v` and `_class`) in the migration tool, shifting their exclusion from the transformation logic to the MongoDB projection layer. This change ensures these fields are excluded by default during migration, but allows users to override this behavior if needed. Documentation, configuration, flags, and tests have all been updated to reflect this new approach.

**Default projection and metadata exclusion:**
* The default value for the `mongo-projection` flag is now set to exclude `__v` and `_class`, both in code (`internal/config/config.go`, `internal/flags/flags.go`) and documentation (`README.md`). This means framework metadata fields are excluded from migrated documents unless the user specifies otherwise. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL51-R51) [[2]](diffhunk://#diff-dea4d60e02b3dedd8b784f4254501a4ad4cc9d10ad45e5e8962582574c82920fL16-R16) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R105) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R137) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L162-R162)

**Transformation logic simplification:**
* The explicit removal of `__v` and `_class` in the transformation layer (`internal/transformer/transformer.go`) has been eliminated, as this is now handled by the MongoDB projection.

**Documentation updates:**
* The README has been updated to clarify the new default projection behavior, including examples and feature descriptions, ensuring users understand that framework metadata is excluded by default but can be included if desired. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R76) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R270-R278)

**Test updates:**
* Unit tests have been updated to reflect the new default projection, removing checks for explicit field removal and adding logic to verify that expected fields are present regardless of extra fields. [[1]](diffhunk://#diff-623285afd36b10830f3d03debfd2d69c23bccc6223330a60479d2513128db5a7L42-R42) [[2]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005R16-R30) [[3]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L54-R74) [[4]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L99-L100) [[5]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L125-L133) [[6]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L149-L150) [[7]](diffhunk://#diff-1b82849a95d06b0984ee9cb231a547c6bcbf5a5ed413f44f79f1719b2621d005L198-L199)