### PR TITLE
feat(completion): Implement completion commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ mongo2dynamo is designed for efficient and reliable data migration, incorporatin
 -   **Automatic Table Management**: Automatically creates DynamoDB tables if they don't exist, with user confirmation prompts (unless auto-approved). **Supports custom primary keys (Partition and Sort Keys).** Waits for table activation before proceeding with migration.
 -   **Real-Time Progress Tracking**: Provides visual progress indicators with real-time status updates, processing rate, and estimated completion time. Progress display can be disabled with `--no-progress` flag for non-interactive environments.
 -   **Prometheus Metrics**: Built-in monitoring with Prometheus-compatible metrics for real-time performance tracking, including document processing rates, error counts, migration duration, and worker pool utilization. Metrics server can be enabled with `--metrics-enabled` flag.
+-   **Shell Completion**: Interactive command-line completion support for bash, zsh, fish, and PowerShell, providing intelligent suggestions for commands, flags, and options to enhance CLI usability.
 
 ## Installation
 
@@ -86,6 +87,10 @@ mongo2dynamo apply --mongo-db mydb --mongo-collection users \
 mongo2dynamo apply --mongo-db mydb --mongo-collection users \
   --metrics-enabled \
   --metrics-addr :2112
+
+# Enable shell completion for better CLI experience
+mongo2dynamo completion zsh | source  # For zsh
+# mongo2dynamo completion bash | source  # For bash
 ```
 
 ## Configuration
@@ -237,6 +242,57 @@ Successfully migrated 2,000,000 documents.
 ### `version` - Show Version
 
 Displays version information including Git commit and build date.
+
+### `completion` - Generate Shell Completion
+
+Generates shell completion scripts for interactive command-line usage.
+
+**Supported Shells:**
+- **Bash**: `mongo2dynamo completion bash`
+- **Zsh**: `mongo2dynamo completion zsh`
+- **Fish**: `mongo2dynamo completion fish`
+- **PowerShell**: `mongo2dynamo completion powershell`
+
+**Usage Examples:**
+
+**Bash:**
+```bash
+# Load completion for current session
+source <(mongo2dynamo completion bash)
+
+# Load completion permanently (add to ~/.bashrc)
+mongo2dynamo completion bash > ~/.mongo2dynamo/completion.bash
+echo "source ~/.mongo2dynamo/completion.bash" >> ~/.bashrc
+```
+
+**Zsh:**
+```bash
+# Load completion for current session
+source <(mongo2dynamo completion zsh)
+
+# Load completion permanently (add to ~/.zshrc)
+mongo2dynamo completion zsh > ~/.mongo2dynamo/completion.zsh
+echo "source ~/.mongo2dynamo/completion.zsh" >> ~/.zshrc
+```
+
+**Fish:**
+```bash
+# Load completion for current session
+mongo2dynamo completion fish | source
+
+# Load completion permanently
+mongo2dynamo completion fish > ~/.config/fish/completions/mongo2dynamo.fish
+```
+
+**PowerShell:**
+```powershell
+# Load completion for current session
+mongo2dynamo completion powershell | Out-String | Invoke-Expression
+
+# Load completion permanently (add to PowerShell profile)
+mongo2dynamo completion powershell > $PROFILE\mongo2dynamo-completion.ps1
+Add-Content $PROFILE "& '$PROFILE\mongo2dynamo-completion.ps1'"
+```
 
 ## How It Works
 

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -1,0 +1,36 @@
+package completion
+
+import (
+	"mongo2dynamo/internal/completion"
+
+	"github.com/spf13/cobra"
+)
+
+var CompletionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion script",
+	Long: `Generate shell completion script for mongo2dynamo.
+
+The completion script supports bash, zsh, fish, and powershell.
+To load completions in your current shell session:
+
+Bash:
+  $ source <(mongo2dynamo completion bash)
+
+Zsh:
+  $ source <(mongo2dynamo completion zsh)
+
+Fish:
+  $ mongo2dynamo completion fish | source
+
+PowerShell:
+  PS> mongo2dynamo completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, write to a file and source in your shell's config file e.g. ~/.bashrc or ~/.zshrc.`,
+	ValidArgs: completion.GetSupportedShells(),
+	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		shell := args[0]
+		return completion.GenerateCompletion(cmd, shell)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"mongo2dynamo/cmd/apply"
+	"mongo2dynamo/cmd/completion"
 	"mongo2dynamo/cmd/plan"
 	"mongo2dynamo/cmd/version"
 )
@@ -31,4 +32,5 @@ func init() {
 	rootCmd.AddCommand(apply.ApplyCmd)
 	rootCmd.AddCommand(plan.PlanCmd)
 	rootCmd.AddCommand(version.VersionCmd)
+	rootCmd.AddCommand(completion.CompletionCmd)
 }

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -1,0 +1,44 @@
+package completion
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// GenerateCompletion generates shell completion script for the given shell.
+func GenerateCompletion(cmd *cobra.Command, shell string) error {
+	switch shell {
+	case "bash":
+		if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
+			return fmt.Errorf("failed to generate bash completion: %w", err)
+		}
+		return nil
+	case "zsh":
+		if err := cmd.Root().GenZshCompletion(os.Stdout); err != nil {
+			return fmt.Errorf("failed to generate zsh completion: %w", err)
+		}
+		return nil
+	case "fish":
+		if err := cmd.Root().GenFishCompletion(os.Stdout, true); err != nil {
+			return fmt.Errorf("failed to generate fish completion: %w", err)
+		}
+		return nil
+	case "powershell":
+		if err := cmd.Root().GenPowerShellCompletion(os.Stdout); err != nil {
+			return fmt.Errorf("failed to generate powershell completion: %w", err)
+		}
+		return nil
+	default:
+		if err := cmd.Help(); err != nil {
+			return fmt.Errorf("failed to display help: %w", err)
+		}
+		return nil
+	}
+}
+
+// GetSupportedShells returns the list of supported shell types.
+func GetSupportedShells() []string {
+	return []string{"bash", "zsh", "fish", "powershell"}
+}

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -1,0 +1,65 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateCompletion(t *testing.T) {
+	// Create a root command for testing.
+	rootCmd := &cobra.Command{Use: "test"}
+	rootCmd.AddCommand(&cobra.Command{Use: "subcommand"})
+
+	tests := []struct {
+		name        string
+		shell       string
+		expectError bool
+	}{
+		{
+			name:        "bash completion",
+			shell:       "bash",
+			expectError: false,
+		},
+		{
+			name:        "zsh completion",
+			shell:       "zsh",
+			expectError: false,
+		},
+		{
+			name:        "fish completion",
+			shell:       "fish",
+			expectError: false,
+		},
+		{
+			name:        "powershell completion",
+			shell:       "powershell",
+			expectError: false,
+		},
+		{
+			name:        "invalid shell",
+			shell:       "invalid",
+			expectError: false, // Help() doesn't return an error.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GenerateCompletion(rootCmd, tt.shell)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetSupportedShells(t *testing.T) {
+	shells := GetSupportedShells()
+	expectedShells := []string{"bash", "zsh", "fish", "powershell"}
+
+	assert.ElementsMatch(t, expectedShells, shells)
+	assert.Len(t, shells, 4)
+}


### PR DESCRIPTION
This pull request adds shell completion support to the `mongo2dynamo` CLI, enabling users to generate completion scripts for bash, zsh, fish, and powershell. The implementation includes a new command, supporting functions, and associated tests.

**Shell Completion Feature:**

* Added the `completion` subcommand to the CLI, allowing users to generate shell completion scripts for supported shells via `mongo2dynamo completion [bash|zsh|fish|powershell]`. (`cmd/completion/completion.go`, [cmd/completion/completion.goR1-R36](diffhunk://#diff-4a300e4f7c47c9f3c79bc726a0ad1bd5c0544729060dd9d52794b58259e30528R1-R36))
* Registered the new `completion` command with the root command, making it available in the CLI. (`cmd/root.go`, [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR9) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR35)

**Completion Logic & Testing:**

* Implemented the core logic for generating shell completion scripts and listing supported shells in `internal/completion/completion.go`. (`internal/completion/completion.go`, [internal/completion/completion.goR1-R44](diffhunk://#diff-106ac4418cd985d30eb0ee758e4c3c76c88a6fd53863cad4acbe13cf4eeb70e1R1-R44))
* Added unit tests for completion generation and supported shell listing to ensure reliability and correctness. (`internal/completion/completion_test.go`, [internal/completion/completion_test.goR1-R65](diffhunk://#diff-151e5fb74d91b325cb9b6e9a89e1ff9f8e015c54bf78f4a18f8cde9c4376aa76R1-R65))