### PR TITLE
fix(metrics): Add graceful shutdown to metrics server

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -162,7 +162,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		metricsManager = metrics.NewMetrics()
 		// Start metrics server in background.
 		go func() {
-			if err := metricsManager.StartMetricsServer(cfg.MetricsAddr); err != nil {
+			if err := metricsManager.StartMetricsServer(ctx, cfg.MetricsAddr); err != nil {
 				cmd.PrintErrf("Failed to start metrics server: %v\n", err)
 			}
 		}()

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -115,7 +115,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 		metricsManager = metrics.NewMetrics()
 		// Start metrics server in background.
 		go func() {
-			if err := metricsManager.StartMetricsServer(cfg.MetricsAddr); err != nil {
+			if err := metricsManager.StartMetricsServer(ctx, cfg.MetricsAddr); err != nil {
 				cmd.PrintErrf("Failed to start metrics server: %v\n", err)
 			}
 		}()

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -92,7 +93,7 @@ func TestMetricsServer(t *testing.T) {
 
 	// Start server.
 	go func() {
-		err := metrics.StartMetricsServer(":0") // Port 0 automatically selects an available port.
+		err := metrics.StartMetricsServer(context.Background(), ":0") // Port 0 automatically selects an available port.
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Errorf("Failed to start metrics server: %v", err)
 		}


### PR DESCRIPTION
This pull request updates the metrics server to support graceful shutdown using a context, improving resource management and reliability. The most important changes are the addition of context handling to the metrics server, updates to function signatures and usage, and improvements to error handling.

**Metrics server improvements:**

* The `StartMetricsServer` method in `internal/metrics/metrics.go` now accepts a `context.Context` argument, allowing the server to shut down gracefully when the context is cancelled.
* The implementation of `StartMetricsServer` was updated to start the server in a goroutine, listen for either context cancellation or server errors, and handle graceful shutdown with a timeout.

**Function signature and usage updates:**

* Calls to `StartMetricsServer` in `cmd/apply/apply.go` and `cmd/plan/plan.go` were updated to pass the context argument. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfL165-R165) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6L118-R118)
* The corresponding test in `internal/metrics/metrics_test.go` was updated to use a context when starting the metrics server.

**Imports and dependencies:**

* Added the `context` package to files that interact with the metrics server to support the new functionality. [[1]](diffhunk://#diff-6e56d7c057f6a96124b78f2b669dd7dface2718c304aece205017d114b3a7088R4) [[2]](diffhunk://#diff-8ea0d64df378dd743e9e7106592591a8568f325916af29bf4980054b6373b370R4)