### PR TITLE
test: Add integration test for completion command

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -341,3 +341,15 @@ func TestVersionCommand(t *testing.T) {
 	require.Regexp(t, `^Git Commit: .+$`, lines[1], "Git Commit line should match expected format")
 	require.Regexp(t, `^Build Date: .+$`, lines[2], "Build Date line should match expected format")
 }
+
+// TestCompletionCommand tests the completion command functionality.
+func TestCompletionCommand(t *testing.T) {
+	// Run the completion command.
+	cmd := exec.Command("go", "run", "../../main.go", "completion", "zsh")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "CLI completion command should not fail")
+
+	// Verify completion output format.
+	outputStr := string(output)
+	require.Contains(t, outputStr, "zsh", "Completion output should contain zsh")
+}


### PR DESCRIPTION
This pull request adds a new integration test to verify the CLI completion command functionality. The most important change is the addition of a test that ensures the completion output for `zsh` is generated correctly.

Testing enhancements:

* Added `TestCompletionCommand` function in `test/integration/integration_test.go` to test the CLI completion command for `zsh`, checking that the command executes without errors and that the output contains "zsh".