### PR TITLE
perf(transformer): Reuse worker pool across Transform calls

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -133,6 +133,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	// Create docTransformer for MongoDB to DynamoDB document conversion.
 	docTransformer := transformer.NewDocTransformer()
+	defer docTransformer.Close()
 
 	// Create dynamoLoader using configuration.
 	dynamoLoader, err := loader.NewDynamoLoader(cmd.Context(), cfg)

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -96,6 +96,7 @@ func runPlan(cmd *cobra.Command, _ []string) error {
 
 	// Create docTransformer for MongoDB to DynamoDB document conversion.
 	docTransformer := transformer.NewDocTransformer()
+	defer docTransformer.Close()
 
 	// Use a cancellable context to shut down the pipeline on error.
 	ctx, cancel := context.WithCancel(cmd.Context())

--- a/internal/common/interfaces.go
+++ b/internal/common/interfaces.go
@@ -19,6 +19,8 @@ type Extractor interface {
 type Transformer interface {
 	// Transform transforms the provided documents into a new format.
 	Transform(ctx context.Context, data []map[string]any) ([]map[string]any, error)
+	// Close releases any resources held by the transformer.
+	Close()
 }
 
 // Loader defines the interface for loading data to a destination.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -76,7 +76,7 @@ func TestMetricsHandler(t *testing.T) {
 	assert.NotNil(t, handler)
 
 	// Test if HTTP handler works properly.
-	req := httptest.NewRequest("GET", "/metrics", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/metrics", nil)
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -3,6 +3,7 @@ package transformer
 import (
 	"context"
 	"runtime"
+	"sync"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -22,15 +23,46 @@ var (
 	DefaultQueueSize  = DefaultMaxWorkers * 2
 )
 
-// DocTransformer transforms MongoDB documents.
-type DocTransformer struct{}
+// transformFunc is the per-document transformation applied by the worker pool.
+func transformFunc(_ context.Context, job worker.Job[map[string]any]) worker.Result[map[string]any] {
+	doc := job.Data
 
-// NewDocTransformer creates a new DocTransformer.
-func NewDocTransformer() common.Transformer {
-	return &DocTransformer{}
+	estimatedFields := len(doc)
+	if estimatedFields == 0 {
+		return worker.Result[map[string]any]{JobID: job.ID, Value: map[string]any{}}
+	}
+
+	newDoc := make(map[string]any, estimatedFields)
+	for k, v := range doc {
+		newDoc[k] = convertValue(v)
+	}
+	return worker.Result[map[string]any]{JobID: job.ID, Value: newDoc}
 }
 
-// Transform removes framework metadata fields while preserving all other fields.
+// DocTransformer transforms MongoDB documents using a shared, reusable worker pool.
+type DocTransformer struct {
+	mu         sync.Mutex
+	pool       *worker.DynamicWorkerPool[map[string]any, map[string]any]
+	poolCancel context.CancelFunc
+	closed     bool
+}
+
+// NewDocTransformer creates a new DocTransformer with a shared worker pool that is reused across Transform calls.
+// The pool lifetime is owned by the transformer, decoupled from any single Transform's ctx, so that pool workers survive across chunk boundaries.
+func NewDocTransformer() common.Transformer {
+	poolCtx, cancel := context.WithCancel(context.Background())
+	pool := worker.NewDynamicWorkerPool(transformFunc, DefaultMinWorkers, DefaultMaxWorkers, DefaultQueueSize, DefaultScaleInterval)
+	pool.SetBackpressureThreshold(0.95)
+	pool.SetBackpressureTimeout(10 * time.Millisecond)
+	pool.Start(poolCtx)
+	return &DocTransformer{
+		pool:       pool,
+		poolCancel: cancel,
+	}
+}
+
+// Transform converts MongoDB documents (e.g., ObjectID → hex string) using the shared worker pool.
+// Concurrent callers are serialized because the underlying pool's Process is not safe for concurrent use (job IDs and result channels are shared).
 func (t *DocTransformer) Transform(
 	ctx context.Context,
 	input []map[string]any,
@@ -39,33 +71,16 @@ func (t *DocTransformer) Transform(
 		return []map[string]any{}, nil
 	}
 
-	// This is the actual transformation logic for a single document.
-	transformFunc := func(_ context.Context, job worker.Job[map[string]any]) worker.Result[map[string]any] {
-		doc := job.Data
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
-		// Use original document size as base capacity estimate.
-		estimatedFields := len(doc)
-		if estimatedFields == 0 {
-			return worker.Result[map[string]any]{JobID: job.ID, Value: map[string]any{}}
+	if t.closed {
+		return []map[string]any{}, &common.TransformError{
+			Reason: "transformer is closed",
 		}
-
-		newDoc := make(map[string]any, estimatedFields)
-		for k, v := range doc {
-			newDoc[k] = convertValue(v)
-		}
-		return worker.Result[map[string]any]{JobID: job.ID, Value: newDoc}
 	}
 
-	// Configure and run the dynamic worker pool.
-	pool := worker.NewDynamicWorkerPool(transformFunc, DefaultMinWorkers, DefaultMaxWorkers, DefaultQueueSize, DefaultScaleInterval)
-	defer pool.Stop()
-
-	// Configure backpressure settings for optimal performance.
-	pool.SetBackpressureThreshold(0.95)                // Start backpressure at 95% channel usage for minimal impact.
-	pool.SetBackpressureTimeout(10 * time.Millisecond) // 10ms timeout for faster response.
-
-	pool.Start(ctx)
-	output, err := pool.Process(ctx, input)
+	output, err := t.pool.Process(ctx, input)
 	if err != nil {
 		return []map[string]any{}, &common.TransformError{
 			Reason: "document transformation failed",
@@ -74,6 +89,20 @@ func (t *DocTransformer) Transform(
 	}
 
 	return output, nil
+}
+
+// Close shuts down the worker pool and releases its goroutines.
+func (t *DocTransformer) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return
+	}
+	t.closed = true
+
+	t.pool.Stop()
+	t.poolCancel()
 }
 
 // convertValue recursively converts values, handling ObjectID references.

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -162,7 +162,7 @@ func TestApplyCommand_WithExistingTable(t *testing.T) {
 	createDynamoTable(t, dynamoClient, "test_table")
 
 	// Run the apply command.
-	cmd := exec.Command("go", "run", "../../main.go", "apply",
+	cmd := exec.CommandContext(t.Context(), "go", "run", "../../main.go", "apply",
 		"--mongo-host", mongoHost,
 		"--mongo-port", mongoPort,
 		"--mongo-db", "testdb",
@@ -232,7 +232,7 @@ func TestApplyCommand_WithAutoCreateTable(t *testing.T) {
 	dynamoClient := setupDynamoDB(t, dynamoHost, dynamoPort)
 
 	// Run the apply command with auto-approve enabled.
-	cmd := exec.Command("go", "run", "../../main.go", "apply",
+	cmd := exec.CommandContext(t.Context(), "go", "run", "../../main.go", "apply",
 		"--mongo-host", mongoHost,
 		"--mongo-port", mongoPort,
 		"--mongo-db", "testdb",
@@ -296,7 +296,7 @@ func TestPlanCommand(t *testing.T) {
 	}()
 
 	// Run the plan command.
-	cmd := exec.Command("go", "run", "../../main.go", "plan",
+	cmd := exec.CommandContext(t.Context(), "go", "run", "../../main.go", "plan",
 		"--mongo-host", mongoHost,
 		"--mongo-port", mongoPort,
 		"--mongo-db", "testdb",
@@ -317,7 +317,7 @@ func TestPlanCommand(t *testing.T) {
 // TestVersionCommand tests the version command functionality.
 func TestVersionCommand(t *testing.T) {
 	// Run the version command.
-	cmd := exec.Command("go", "run", "../../main.go", "version")
+	cmd := exec.CommandContext(t.Context(), "go", "run", "../../main.go", "version")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, "CLI version command should not fail")
 
@@ -340,7 +340,7 @@ func TestVersionCommand(t *testing.T) {
 // TestCompletionCommand tests the completion command functionality.
 func TestCompletionCommand(t *testing.T) {
 	// Run the completion command.
-	cmd := exec.Command("go", "run", "../../main.go", "completion", "zsh")
+	cmd := exec.CommandContext(t.Context(), "go", "run", "../../main.go", "completion", "zsh")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, "CLI completion command should not fail")
 


### PR DESCRIPTION
This pull request introduces significant improvements to resource management and concurrency in the document transformation pipeline, along with minor enhancements to test reliability. The most important changes include adding a `Close` method to the `Transformer` interface, refactoring `DocTransformer` to use a reusable worker pool with proper cleanup, and updating integration and unit tests for better context handling.

**Transformer resource management and concurrency:**

* Added a `Close` method to the `Transformer` interface to allow for explicit resource cleanup by implementations.
* Refactored `DocTransformer` to use a shared, reusable worker pool that persists across multiple `Transform` calls, and is properly cleaned up via the new `Close` method. This prevents resource leaks and improves efficiency when processing multiple chunks. [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L25-L46) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L59-R83) [[3]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R94-R107)
* Ensured thread safety in `DocTransformer` by serializing concurrent calls to `Transform` and guarding cleanup with a mutex. [[1]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6L59-R83) [[2]](diffhunk://#diff-0bdd790131af2e412c47419a9ae26a50bb2ed03be8ba987ebe0c98212c6ad1b6R94-R107)
* Updated the construction and usage of `DocTransformer` in the `apply` and `plan` commands to defer resource cleanup by calling `Close` after use. [[1]](diffhunk://#diff-8638289f8c1e9b2a618f0a42ebce34bcda6c891de9b23cafee22b91c03a532cfR136) [[2]](diffhunk://#diff-87b839377ee0335808df2a16726e25022107352b82a78cd7f3fe355b763f71c6R99)

**Test improvements:**

* Updated integration and unit tests to use context-aware command execution and HTTP requests, improving test reliability and proper resource cancellation. [[1]](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL165-R165) [[2]](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL235-R235) [[3]](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL299-R299) [[4]](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL320-R320) [[5]](diffhunk://#diff-ca62391b26e30e01d1f8cee0eac7829ba8e9b5e22d80eab0e83881086fb4177bL343-R343) [[6]](diffhunk://#diff-8ea0d64df378dd743e9e7106592591a8568f325916af29bf4980054b6373b370L79-R79)