### PR TITLE
chore: Add .claude to ignore claude code related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
 vendor/
+.claude/
 .vscode/
 coverage.out


### PR DESCRIPTION
Add .claude/ to .gitignore. It's Claude Code's local working state (settings.local.json, worktrees/) and should never be committed.