### PR TITLE
fix(loader): Prevent dispatcher goroutine leak on worker error

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -209,8 +209,13 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 		return nil
 	}
 
+	// loadCtx is cancelled when any worker or the dispatcher fails, so the dispatcher unblocks from jobChan sends and other workers stop early.
+	loadCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	jobChan := make(chan []types.WriteRequest)
-	errorChan := make(chan error, DefaultLoaderWorkers)
+	// +1 to accommodate a marshal error from the dispatcher in addition to one error per worker.
+	errorChan := make(chan error, DefaultLoaderWorkers+1)
 	var wg sync.WaitGroup
 
 	// Start a pool of workers.
@@ -220,32 +225,34 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 			defer wg.Done()
 			for {
 				select {
-				case <-ctx.Done(): // Context cancelled from the outside.
+				case <-loadCtx.Done():
 					return
 				case writeRequests, ok := <-jobChan:
 					if !ok { // Channel closed.
 						return
 					}
-					if err := l.batchWrite(ctx, writeRequests); err != nil {
+					if err := l.batchWrite(loadCtx, writeRequests); err != nil {
 						// Non-blocking send.
 						select {
 						case errorChan <- err:
 						default:
 						}
-						return // Stop this worker on first error.
+						cancel() // Signal the dispatcher and other workers to stop.
+						return
 					}
 				}
 			}
 		}()
 	}
 
-	// Dispatch jobs.
+	// Dispatch jobs. Tracked with wg so Load does not return while the goroutine is still running.
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(jobChan)
 		writeRequests := make([]types.WriteRequest, 0, DefaultDynamoBatchSize)
 		for _, item := range data {
-			// Check for cancellation before dispatching new jobs.
-			if ctx.Err() != nil {
+			if loadCtx.Err() != nil {
 				return
 			}
 
@@ -255,13 +262,14 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 				case errorChan <- &common.DataValidationError{Database: "DynamoDB", Op: "marshal", Reason: err.Error(), Err: err}:
 				default:
 				}
-				return // Stop dispatching.
+				cancel()
+				return
 			}
 			writeRequests = append(writeRequests, types.WriteRequest{PutRequest: &types.PutRequest{Item: av}})
 			if len(writeRequests) == DefaultDynamoBatchSize {
 				select {
 				case jobChan <- writeRequests:
-				case <-ctx.Done():
+				case <-loadCtx.Done():
 					return
 				}
 				writeRequests = make([]types.WriteRequest, 0, DefaultDynamoBatchSize)
@@ -270,7 +278,7 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 		if len(writeRequests) > 0 {
 			select {
 			case jobChan <- writeRequests:
-			case <-ctx.Done():
+			case <-loadCtx.Done():
 				return
 			}
 		}

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -326,6 +327,39 @@ func TestDynamoLoader_Load_ContextCancellation(t *testing.T) {
 	err := dynamoLoader.Load(ctx, data)
 	assert.NoError(t, err, "cancelled context should gracefully stop without returning an error from the loader itself")
 	mockClient.AssertNotCalled(t, "BatchWriteItem")
+}
+
+// TestDynamoLoader_Load_NoDispatcherLeakOnWorkerError ensures the dispatcher goroutine exits when all workers fail early.
+// Regression: workers exiting on error left the dispatcher blocked on an unbuffered jobChan send because ctx was never cancelled.
+func TestDynamoLoader_Load_NoDispatcherLeakOnWorkerError(t *testing.T) {
+	mockClient := &MockDBClient{}
+	dynamoLoader := newDynamoLoader(mockClient, "test-table", 0) // No retries to fail fast.
+
+	// Far more items than DefaultLoaderWorkers * DefaultDynamoBatchSize so the dispatcher would still have batches to send after all workers exit on error.
+	itemCount := DefaultLoaderWorkers * DefaultDynamoBatchSize * 4
+	data := make([]map[string]any, itemCount)
+	for i := 0; i < itemCount; i++ {
+		data[i] = map[string]any{"id": fmt.Sprintf("%d", i)}
+	}
+
+	mockClient.On("BatchWriteItem", mock.Anything, mock.Anything).Return(nil, errors.New("dynamodb error"))
+
+	baseline := runtime.NumGoroutine()
+
+	err := dynamoLoader.Load(context.Background(), data)
+	require.Error(t, err)
+
+	// Give goroutines a brief moment to wind down.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	assert.LessOrEqualf(t, runtime.NumGoroutine(), baseline+1,
+		"dispatcher or workers leaked: baseline=%d, after=%d", baseline, runtime.NumGoroutine())
 }
 
 func TestCalculateBackoffWithJitter(t *testing.T) {


### PR DESCRIPTION
This pull request improves the robustness of the `DynamoLoader.Load` method by ensuring that all goroutines (workers and dispatcher) are properly cancelled and cleaned up in error scenarios, preventing goroutine leaks. It also adds a regression test to verify that the dispatcher goroutine does not leak when all workers fail early.

**Goroutine cancellation and error handling improvements:**

* Refactored `DynamoLoader.Load` to use a dedicated `loadCtx` context that is cancelled when any worker or the dispatcher encounters an error, ensuring all goroutines exit promptly and no goroutine leaks occur. The dispatcher and workers now consistently check `loadCtx` for cancellation. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR212-R218) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL223-R255) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL258-R272) [[4]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL273-R281)
* Increased the buffer size of `errorChan` to accommodate possible errors from both dispatcher and workers, preventing blocking on error reporting.

**Testing improvements:**

* Added `TestDynamoLoader_Load_NoDispatcherLeakOnWorkerError` to verify that the dispatcher goroutine exits when all workers fail early, preventing goroutine leaks in this regression scenario. This test uses the `runtime` package to count goroutines before and after the operation. [[1]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403R7) [[2]](diffhunk://#diff-e69e5adc1cd7ac8fe3e68789c2ce95dbb0a314c770f2b4c07c0952834c4cb403R332-R364)

These changes significantly improve the reliability and maintainability of the loader by ensuring proper resource cleanup and providing regression coverage.