### PR TITLE
perf: Skip conversion alloc and pool batch slices

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -25,6 +25,24 @@ const (
 	DefaultLoaderWorkers        = 10
 )
 
+// writeRequestBatchPool reuses []types.WriteRequest backing arrays across batches to reduce GC pressure on large migrations.
+// Pool stores *[]types.WriteRequest (not the slice value) so Put avoids the interface{} boxing allocation that sync.Pool incurs for non-pointer types.
+var writeRequestBatchPool = sync.Pool{
+	New: func() any {
+		s := make([]types.WriteRequest, 0, DefaultDynamoBatchSize)
+		return &s
+	},
+}
+
+func getWriteRequestBatch() *[]types.WriteRequest {
+	return writeRequestBatchPool.Get().(*[]types.WriteRequest)
+}
+
+func putWriteRequestBatch(b *[]types.WriteRequest) {
+	*b = (*b)[:0]
+	writeRequestBatchPool.Put(b)
+}
+
 // DBClient defines the interface for DynamoDB operations used by Loader.
 type DBClient interface {
 	CreateTable(ctx context.Context, params *dynamodb.CreateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error)
@@ -213,7 +231,7 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 	loadCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	jobChan := make(chan []types.WriteRequest)
+	jobChan := make(chan *[]types.WriteRequest)
 	// +1 to accommodate a marshal error from the dispatcher in addition to one error per worker.
 	errorChan := make(chan error, DefaultLoaderWorkers+1)
 	var wg sync.WaitGroup
@@ -227,11 +245,13 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 				select {
 				case <-loadCtx.Done():
 					return
-				case writeRequests, ok := <-jobChan:
+				case batch, ok := <-jobChan:
 					if !ok { // Channel closed.
 						return
 					}
-					if err := l.batchWrite(loadCtx, writeRequests); err != nil {
+					err := l.batchWrite(loadCtx, *batch)
+					putWriteRequestBatch(batch)
+					if err != nil {
 						// Non-blocking send.
 						select {
 						case errorChan <- err:
@@ -250,9 +270,10 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 	go func() {
 		defer wg.Done()
 		defer close(jobChan)
-		writeRequests := make([]types.WriteRequest, 0, DefaultDynamoBatchSize)
+		batch := getWriteRequestBatch()
 		for _, item := range data {
 			if loadCtx.Err() != nil {
+				putWriteRequestBatch(batch)
 				return
 			}
 
@@ -262,25 +283,31 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 				case errorChan <- &common.DataValidationError{Database: "DynamoDB", Op: "marshal", Reason: err.Error(), Err: err}:
 				default:
 				}
+				putWriteRequestBatch(batch)
 				cancel()
 				return
 			}
-			writeRequests = append(writeRequests, types.WriteRequest{PutRequest: &types.PutRequest{Item: av}})
-			if len(writeRequests) == DefaultDynamoBatchSize {
+			*batch = append(*batch, types.WriteRequest{PutRequest: &types.PutRequest{Item: av}})
+			if len(*batch) == DefaultDynamoBatchSize {
 				select {
-				case jobChan <- writeRequests:
+				case jobChan <- batch:
 				case <-loadCtx.Done():
+					putWriteRequestBatch(batch)
 					return
 				}
-				writeRequests = make([]types.WriteRequest, 0, DefaultDynamoBatchSize)
+				batch = getWriteRequestBatch()
 			}
 		}
-		if len(writeRequests) > 0 {
+		if len(*batch) > 0 {
 			select {
-			case jobChan <- writeRequests:
+			case jobChan <- batch:
 			case <-loadCtx.Done():
+				putWriteRequestBatch(batch)
 				return
 			}
+		} else {
+			// Empty trailing batch (full data was a multiple of batch size); return immediately so it can be reused.
+			putWriteRequestBatch(batch)
 		}
 	}()
 

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -106,34 +106,41 @@ func (t *DocTransformer) Close() {
 }
 
 // convertValue recursively converts values, handling ObjectID references.
+// For []any and map[string]any, the original is returned when no nested element needs conversion;
+// callers may share the result with the input. Downstream consumers (attributevalue.MarshalMap) only read,
+// so the shallow-share is safe and avoids per-document allocations on plain JSON-like sub-trees.
 func convertValue(v any) any {
 	switch val := v.(type) {
 	case primitive.ObjectID:
 		// Convert ObjectID to hex string for references.
 		return val.Hex()
 	case []any:
-		// Handle arrays (e.g., array of ObjectIDs).
+		if !needsConversion(val) {
+			return v
+		}
 		result := make([]any, len(val))
 		for i, item := range val {
 			result[i] = convertValue(item)
 		}
 		return result
 	case map[string]any:
-		// Handle nested objects.
+		if !needsConversion(val) {
+			return v
+		}
 		result := make(map[string]any, len(val))
 		for k, item := range val {
 			result[k] = convertValue(item)
 		}
 		return result
 	case bson.M:
-		// Handle BSON maps.
+		// bson.M is always normalized to map[string]any per the established contract.
 		result := make(map[string]any, len(val))
 		for k, item := range val {
 			result[k] = convertValue(item)
 		}
 		return result
 	case bson.A:
-		// Handle BSON arrays.
+		// bson.A is always normalized to []any per the established contract.
 		result := make([]any, len(val))
 		for i, item := range val {
 			result[i] = convertValue(item)
@@ -142,5 +149,33 @@ func convertValue(v any) any {
 	default:
 		// For other types, return as-is.
 		return v
+	}
+}
+
+// needsConversion reports whether v (or any nested element) would change when passed through convertValue.
+// It is allocation-free and lets convertValue skip allocating containers when nothing inside changes.
+func needsConversion(v any) bool {
+	switch val := v.(type) {
+	case primitive.ObjectID:
+		return true
+	case bson.M, bson.A:
+		// These types are always re-typed to map[string]any / []any.
+		return true
+	case []any:
+		for _, item := range val {
+			if needsConversion(item) {
+				return true
+			}
+		}
+		return false
+	case map[string]any:
+		for _, item := range val {
+			if needsConversion(item) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
 	}
 }

--- a/internal/transformer/transformer_test.go
+++ b/internal/transformer/transformer_test.go
@@ -427,6 +427,32 @@ func TestConvertValue(t *testing.T) {
 	}
 }
 
+// TestConvertValue_FastPathPreservesReference verifies the fast-path returns the original container reference
+// when no nested value needs conversion, avoiding allocation.
+func TestConvertValue_FastPathPreservesReference(t *testing.T) {
+	// Nested slice and map without any ObjectID or bson type.
+	inner := []any{"a", 1, true}
+	outer := map[string]any{"items": inner, "name": "plain"}
+
+	got := convertValue(outer).(map[string]any)
+	if !reflect.DeepEqual(got, outer) {
+		t.Fatalf("expected unchanged value, got %+v", got)
+	}
+
+	gotInner, ok := got["items"].([]any)
+	if !ok {
+		t.Fatalf("expected []any for items, got %T", got["items"])
+	}
+
+	// Both the outer map and the inner slice should be the same reference as input (fast-path).
+	if reflect.ValueOf(got).Pointer() != reflect.ValueOf(outer).Pointer() {
+		t.Errorf("outer map: expected same reference (fast-path), got new allocation")
+	}
+	if reflect.ValueOf(gotInner).Pointer() != reflect.ValueOf(inner).Pointer() {
+		t.Errorf("inner slice: expected same reference (fast-path), got new allocation")
+	}
+}
+
 func TestConvertValue_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This pull request introduces optimizations to both the DynamoDB loader and the BSON-to-JSON transformer, focusing on reducing memory allocations and improving performance during large data migrations. The changes include a new pooling mechanism for DynamoDB write batches, more efficient handling of container allocations in value transformation, and corresponding tests to ensure correctness.

**Loader optimizations:**

* Added a `sync.Pool`-backed `writeRequestBatchPool` to reuse `[]types.WriteRequest` slices, minimizing garbage collection pressure and allocations during batch processing in `internal/loader/loader.go`.
* Refactored the batching logic in `DynamoLoader.Load` to use pooled batches, ensuring batches are reset and returned to the pool after use, and updated worker and dispatcher code to handle pointer-based batches. [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL216-R234) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL230-R254) [[3]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL253-R276) [[4]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dR286-R310)

**Transformer optimizations:**

* Updated `convertValue` in `internal/transformer/transformer.go` to avoid allocating new containers for `[]any` and `map[string]any` inputs when no nested value requires conversion, allowing safe shallow sharing for read-only consumers.
* Introduced the `needsConversion` helper function to efficiently detect whether a value or any nested element requires conversion, enabling the fast-path optimization in `convertValue`.

**Testing improvements:**

* Added `TestConvertValue_FastPathPreservesReference` to verify that the fast-path in `convertValue` returns the original references for unchanged containers, preventing unnecessary allocations.