### PR TITLE
refactor:  Tighten ctx response and atomic reuse

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -190,6 +190,31 @@ func (l *DynamoLoader) waitForTableActive(ctx context.Context) error {
 	defer cancel()
 
 	for {
+		output, err := l.client.DescribeTable(timeoutCtx, &dynamodb.DescribeTableInput{
+			TableName: &l.table,
+		})
+		if err != nil {
+			if timeoutCtx.Err() != nil {
+				return &common.DatabaseOperationError{
+					Database: "DynamoDB",
+					Op:       "wait for table active",
+					Reason:   "timeout waiting for table to become active",
+					Err:      timeoutCtx.Err(),
+				}
+			}
+			return &common.DatabaseOperationError{
+				Database: "DynamoDB",
+				Op:       "describe table",
+				Reason:   err.Error(),
+				Err:      err,
+			}
+		}
+
+		if output.Table.TableStatus == types.TableStatusActive {
+			fmt.Printf("Table '%s' is now active and ready for use.\n", l.table)
+			return nil
+		}
+
 		select {
 		case <-timeoutCtx.Done():
 			return &common.DatabaseOperationError{
@@ -198,25 +223,7 @@ func (l *DynamoLoader) waitForTableActive(ctx context.Context) error {
 				Reason:   "timeout waiting for table to become active",
 				Err:      timeoutCtx.Err(),
 			}
-		default:
-			output, err := l.client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
-				TableName: &l.table,
-			})
-			if err != nil {
-				return &common.DatabaseOperationError{
-					Database: "DynamoDB",
-					Op:       "describe table",
-					Reason:   err.Error(),
-					Err:      err,
-				}
-			}
-
-			if output.Table.TableStatus == types.TableStatusActive {
-				fmt.Printf("Table '%s' is now active and ready for use.\n", l.table)
-				return nil
-			}
-
-			time.Sleep(CheckIntervalForTableActive)
+		case <-time.After(CheckIntervalForTableActive):
 		}
 	}
 }

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -321,8 +321,11 @@ func (l *DynamoLoader) Load(ctx context.Context, data []map[string]any) error {
 	wg.Wait()
 	close(errorChan)
 
-	// Return the first error encountered.
-	return <-errorChan
+	var errs []error
+	for err := range errorChan {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 // batchWrite writes a batch of items to DynamoDB.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -177,27 +177,33 @@ func (p *DynamicWorkerPool[T, V]) Process(ctx context.Context, jobsData []T) ([]
 
 // sendJobs sends jobs to the worker pool.
 func (p *DynamicWorkerPool[T, V]) sendJobs(ctx context.Context, jobsData []T) {
-	// Check backpressure with dynamic frequency based on workload.
-	checkFrequency := p.getBackpressureCheckFrequency()
+	// checkFrequency adapts to load each time the backpressure block runs; lazy-initialize to a conservative value for the very first iteration.
+	checkFrequency := BackpressureCheckFrequencyLow
 	backpressureCounter := 0
 
 	for i, data := range jobsData {
 		atomic.AddInt64(&p.pendingJobs, 1)
 
-		if backpressureCounter == 0 && p.shouldApplyBackpressure() {
-			// Use atomic increment to minimize lock contention.
-			atomic.AddInt64(&p.backpressureStats.BackpressureHits, 1)
+		if backpressureCounter == 0 {
+			// Load pendingJobs once and reuse for both the backpressure decision and the check-frequency calculation.
+			pending := atomic.LoadInt64(&p.pendingJobs)
+			if shouldApplyBackpressureFor(pending, p.queueSize, p.backpressureThreshold) {
+				// Use atomic increment to minimize lock contention.
+				atomic.AddInt64(&p.backpressureStats.BackpressureHits, 1)
 
-			// Quick backpressure check with minimal delay.
-			select {
-			case <-p.flowControlChan:
-				// Flow control signal received, continue.
-			case <-time.After(1 * time.Millisecond):
-				// Minimal timeout to minimize performance impact.
-			case <-ctx.Done():
-				atomic.AddInt64(&p.pendingJobs, -1)
-				return
+				// Quick backpressure check with minimal delay.
+				select {
+				case <-p.flowControlChan:
+					// Flow control signal received, continue.
+				case <-time.After(1 * time.Millisecond):
+					// Minimal timeout to minimize performance impact.
+				case <-ctx.Done():
+					atomic.AddInt64(&p.pendingJobs, -1)
+					return
+				}
 			}
+			// Refresh check frequency from the same atomic read so it tracks current load.
+			checkFrequency = backpressureCheckFrequencyFor(pending, p.queueSize)
 		}
 
 		// Increment counter and reset when reaching check frequency.
@@ -515,23 +521,25 @@ func (p *DynamicWorkerPool[T, V]) adjustFlowControl() {
 
 // shouldApplyBackpressure determines if backpressure should be applied.
 func (p *DynamicWorkerPool[T, V]) shouldApplyBackpressure() bool {
-	// Quick check: if pending jobs are very low, no need for backpressure.
-	pending := atomic.LoadInt64(&p.pendingJobs)
-	if pending < DefaultMinPendingJobsForBackpressure {
-		return false
-	}
-
-	// Only check backpressure if we have significant pending jobs.
-	queueSize := p.queueSize
-	return float64(pending) > float64(queueSize)*p.backpressureThreshold
+	return shouldApplyBackpressureFor(atomic.LoadInt64(&p.pendingJobs), p.queueSize, p.backpressureThreshold)
 }
 
 // getBackpressureCheckFrequency returns dynamic check frequency based on workload.
 func (p *DynamicWorkerPool[T, V]) getBackpressureCheckFrequency() int {
-	pending := atomic.LoadInt64(&p.pendingJobs)
-	queueSize := p.queueSize
+	return backpressureCheckFrequencyFor(atomic.LoadInt64(&p.pendingJobs), p.queueSize)
+}
 
-	// Dynamic frequency: more pending jobs = less frequent checks.
+// shouldApplyBackpressureFor decides whether backpressure should be applied for the given pending count.
+// Split from shouldApplyBackpressure so callers that already hold a pendingJobs snapshot can reuse it.
+func shouldApplyBackpressureFor(pending int64, queueSize int, threshold float64) bool {
+	if pending < DefaultMinPendingJobsForBackpressure {
+		return false
+	}
+	return float64(pending) > float64(queueSize)*threshold
+}
+
+// backpressureCheckFrequencyFor computes the dynamic check frequency from a pendingJobs snapshot.
+func backpressureCheckFrequencyFor(pending int64, queueSize int) int {
 	switch {
 	case pending > int64(queueSize*3/4):
 		return BackpressureCheckFrequencyHigh

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -519,18 +519,8 @@ func (p *DynamicWorkerPool[T, V]) adjustFlowControl() {
 	}
 }
 
-// shouldApplyBackpressure determines if backpressure should be applied.
-func (p *DynamicWorkerPool[T, V]) shouldApplyBackpressure() bool {
-	return shouldApplyBackpressureFor(atomic.LoadInt64(&p.pendingJobs), p.queueSize, p.backpressureThreshold)
-}
-
-// getBackpressureCheckFrequency returns dynamic check frequency based on workload.
-func (p *DynamicWorkerPool[T, V]) getBackpressureCheckFrequency() int {
-	return backpressureCheckFrequencyFor(atomic.LoadInt64(&p.pendingJobs), p.queueSize)
-}
-
 // shouldApplyBackpressureFor decides whether backpressure should be applied for the given pending count.
-// Split from shouldApplyBackpressure so callers that already hold a pendingJobs snapshot can reuse it.
+// Takes pending as a parameter so callers can reuse a single atomic snapshot across related decisions.
 func shouldApplyBackpressureFor(pending int64, queueSize int, threshold float64) bool {
 	if pending < DefaultMinPendingJobsForBackpressure {
 		return false


### PR DESCRIPTION
This pull request refactors and improves the logic for backpressure handling in the dynamic worker pool and error aggregation in the DynamoDB loader. The main changes include making backpressure checks more efficient and accurate, simplifying the logic for waiting on DynamoDB table activation, and improving error reporting by aggregating all errors instead of returning only the first one.

**Worker Pool Backpressure Handling Improvements:**

- Refactored backpressure logic to use a new function `shouldApplyBackpressureFor`, which takes a snapshot of `pendingJobs` and uses it for both the backpressure decision and check frequency calculation, reducing redundant atomic operations (`internal/worker/worker.go`). [[1]](diffhunk://#diff-07ddc6f55e0be281f6ab413f6e67b27ecc1a9f03f8a58887f17ee011b56a7cbbL180-R190) [[2]](diffhunk://#diff-07ddc6f55e0be281f6ab413f6e67b27ecc1a9f03f8a58887f17ee011b56a7cbbL516-R532)
- Updated the check frequency logic to recalculate dynamically based on the current load, improving responsiveness to workload changes (`internal/worker/worker.go`). [[1]](diffhunk://#diff-07ddc6f55e0be281f6ab413f6e67b27ecc1a9f03f8a58887f17ee011b56a7cbbR205-R207) [[2]](diffhunk://#diff-07ddc6f55e0be281f6ab413f6e67b27ecc1a9f03f8a58887f17ee011b56a7cbbL516-R532)

**DynamoDB Loader Improvements:**

- Changed the error handling in `Load` to aggregate all errors encountered during batch processing using `errors.Join`, instead of returning only the first error (`internal/loader/loader.go`).
- Refactored the `waitForTableActive` method to simplify the polling logic and ensure that timeouts are handled correctly and consistently, reducing potential race conditions (`internal/loader/loader.go`). [[1]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL193-R204) [[2]](diffhunk://#diff-afdf8be331a1531683f3818f286f124b7021395805089e3bbe3c6d7d3af4c37dL219-R226)